### PR TITLE
perform clock intialization and clock test only on primary processor

### DIFF
--- a/libipl/p10/common.C
+++ b/libipl/p10/common.C
@@ -218,6 +218,7 @@ bool ipl_check_functional_master(void)
 	return true;
 }
 
+
 void ipl_log_sbe_ffdc(struct pdbg_target *pib)
 {
 	uint8_t *ffdc = NULL;
@@ -302,6 +303,26 @@ int ipl_set_sbe_state_all_sec(enum sbe_state state)
 		}
 	}
 	return ret;
+}
+
+struct pdbg_target *ipl_get_functional_primary_proc(void)
+{
+	struct pdbg_target *proc = NULL;
+
+	pdbg_for_each_class_target("proc", proc)
+	{
+		if (!ipl_is_master_proc(proc))
+			continue;
+
+		if (!ipl_is_functional(proc)) {
+			ipl_log(IPL_ERROR,
+				"Primary processor(%d) is not functional\n",
+				pdbg_target_index(proc));
+			return NULL;
+		}
+		return proc;
+	}
+	return NULL;
 }
 
 void ipl_process_fapi_error(const fapi2::ReturnCode& fapirc,

--- a/libipl/p10/common.H
+++ b/libipl/p10/common.H
@@ -49,6 +49,13 @@ bool ipl_is_functional(struct pdbg_target *target);
 bool ipl_check_functional_master(void);
 
 /**
+ * @brief Get functional primary processor
+ *
+ * @return On success return pointer to functional primary proc, else NULL
+ */
+struct pdbg_target *ipl_get_functional_primary_proc(void);
+
+/**
  * @brief Fetch and log SBE FFDC data if available
  *
  * param[in] pib pdbg_target

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -730,60 +730,60 @@ static int ipl_set_ref_clock(void)
 	struct pdbg_target *proc;
 	int rc = 0;
 	uint8_t clock_count = 0;
-
+	fapi2::ReturnCode fapirc;
 	if (ipl_type() == IPL_TYPE_MPIPL)
 		return -1;
 
 	ipl_log(IPL_INFO, "Istep: set_ref_clock: started\n");
 
-	if(initialize_and_check_clock_chip(clock_count)) {
-		ipl_log(IPL_ERROR, "Clock initialization failed\n");
+	proc = ipl_get_functional_primary_proc();
+	if (proc == NULL) {
+		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
-	if(clock_count != 1 && clock_count != 2) {
-		ipl_log(IPL_ERROR, "Invalid number (%d) of clock target found\n",
-							clock_count);
-
+	if (initialize_and_check_clock_chip(clock_count)) {
+		ipl_log(IPL_ERROR, "Clock initialization failed\n");
+		return 1;
+	}
+	if (clock_count != 1 && clock_count != 2) {
+		ipl_log(IPL_ERROR,
+			"Invalid number (%d) of clock target found\n",
+			clock_count);
 		ipl_plat_procedure_error_handler(IPL_ERR_INVALID_NUM_CLOCK);
 		return 1;
 	}
 
-	pdbg_for_each_class_target("proc", proc) {
-		fapi2::ReturnCode fapirc;
-
-		if (!ipl_is_functional(proc))
-			continue;
-
-		// Check if system have clocks to enable redundant mode,
-		// If yes set attribute to enable redundant mode.
-		// Default value of attribute will be for non-redundant mode
-		if(clock_count == NUM_CLOCK_FOR_REDUNDANT_MODE) {
-			fapi2::ATTR_CP_REFCLOCK_SELECT_Type clock_select =
-				fapi2::ENUM_ATTR_CP_REFCLOCK_SELECT_BOTH_OSC0;
-			if(!pdbg_target_set_attribute(
-					proc, "ATTR_CP_REFCLOCK_SELECT", 1, 1, &clock_select)) {
-
-				ipl_log(IPL_ERROR, "Attribute CP_REFCLOCK_SELECT update failed"
-					" for proc %d \n", pdbg_target_index(proc));
-				ipl_plat_procedure_error_handler(IPL_ERR_ATTR_WRITE);
-				rc++;
-				continue;
-			}
-		}
-
-		ipl_log(IPL_INFO, "Running p10_setup_ref_clock HWP on processor %d\n",
-			pdbg_target_index(proc));
-		fapirc = p10_setup_ref_clock(proc);
-		if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
-			ipl_log(IPL_ERROR, "Istep set_ref_clock failed on chip %s, rc=%d \n",
-				pdbg_target_path(proc), fapirc);
+	// Check if system have clocks to enable redundant mode,
+	// If yes set attribute to enable redundant mode.
+	// Default value of attribute will be for non-redundant mode
+	if (clock_count == NUM_CLOCK_FOR_REDUNDANT_MODE) {
+		fapi2::ATTR_CP_REFCLOCK_SELECT_Type clock_select =
+			fapi2::ENUM_ATTR_CP_REFCLOCK_SELECT_BOTH_OSC0;
+		if (!pdbg_target_set_attribute(proc, "ATTR_CP_REFCLOCK_SELECT",
+					1, 1, &clock_select)) {
+			ipl_log(IPL_ERROR,
+				"Attribute CP_REFCLOCK_SELECT update failed"
+				" for proc %d \n",
+				pdbg_target_index(proc));
+			ipl_plat_procedure_error_handler(IPL_ERR_ATTR_WRITE);
 			rc++;
+			return 1;
 		}
-
-		ipl_process_fapi_error(fapirc, proc);
 	}
 
+	ipl_log(IPL_INFO,
+		"Running p10_setup_ref_clock HWP on primary processor %d\n",
+		pdbg_target_index(proc));
+	fapirc = p10_setup_ref_clock(proc);
+	if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
+		ipl_log(IPL_ERROR,
+			"Istep set_ref_clock failed on chip %s, rc=%d \n",
+			pdbg_target_path(proc), fapirc);
+		rc++;
+	}
+
+	ipl_process_fapi_error(fapirc, proc);
 	return rc;
 }
 

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -790,33 +790,35 @@ static int ipl_set_ref_clock(void)
 static int ipl_proc_clock_test(void)
 {
 	struct pdbg_target *proc;
-	int rc = 0;
+	int rc = 0; 
+	fapi2::ReturnCode fapirc;
 
 	if (ipl_type() == IPL_TYPE_MPIPL)
 		return -1;
 
 	ipl_log(IPL_INFO, "Istep: proc_clock_test: started\n");
 
-	pdbg_for_each_class_target("proc", proc) {
-		fapi2::ReturnCode fapirc;
-
-		if (!ipl_is_functional(proc))
-			continue;
-
-		ipl_log(IPL_INFO,"Running p10_clock_test HWP on processor %d\n",
-			pdbg_target_index(proc));
-		fapirc = p10_clock_test(proc);
-		if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
-			ipl_log(IPL_ERROR, "HWP clock_test failed on proc %d, rc=%d\n",
-				pdbg_target_index(proc), fapirc);
-			rc++;
-		}
-
-		ipl_process_fapi_error(fapirc, proc);
+	proc = ipl_get_functional_primary_proc();
+	if (proc == NULL) {
+		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
+		return 1;
 	}
+
+	ipl_log(IPL_INFO,
+		"Running p10_clock_test HWP on primary processor %d\n",
+		pdbg_target_index(proc));
+	fapirc = p10_clock_test(proc);
+	if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
+		ipl_log(IPL_ERROR, "HWP clock_test failed on proc %d, rc=%d\n",
+			pdbg_target_index(proc), fapirc);
+		rc++;
+	}
+
+	ipl_process_fapi_error(fapirc, proc);
 
 	return rc;
 }
+
 
 static int ipl_proc_prep_ipl(void)
 {


### PR DESCRIPTION
BMC is responsible for primary processor clock initialization and clock test and host is responsible for secondary processor clock initialization and test.

Recently Hostboot added support to run non-primary processor set_ref clock support. This commit is to avoid duplicate hwp procedure execution on secondary prcessor.

Made changes to perform clock initialization and clock test only on primary processor.