### PR TITLE
libipl: p10: Create PEL for guard file exception

### DIFF
--- a/libipl/libipl.H
+++ b/libipl/libipl.H
@@ -38,6 +38,7 @@ enum ipl_error_type {
 	IPL_ERR_CLK,
 	IPL_ERR_INVALID_NUM_CLOCK,
 	IPL_ERR_ATTR_WRITE,
+	IPL_ERR_GUARD_PARTITION_ACCESS, 
 };
 
 typedef std::map<ipl_error_type, const char*> err_msg_map_type;
@@ -55,6 +56,7 @@ const err_msg_map_type err_msg_map = {
 	{ IPL_ERR_CLK, "Clock hw initialization is failed" },
 	{ IPL_ERR_INVALID_NUM_CLOCK, "Invalid number of clock targets found" },
 	{ IPL_ERR_ATTR_WRITE, "Device tree attribute write failed" },
+	{ IPL_ERR_GUARD_PARTITION_ACCESS, "Guard partition access failure"},
 };
 
 // Error info structure.

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -21,6 +21,7 @@ extern "C" {
 #include <libguard/guard_interface.hpp>
 #include <libguard/guard_entity.hpp>
 #include <libguard/include/guard_record.hpp>
+#include <libguard/guard_exception.hpp>
 #include <filesystem>
 #include <fstream>
 #include <array>
@@ -289,64 +290,92 @@ static void process_guard_records()
 		return;
 	}
 
-	openpower::guard::libguard_init(false);
+	try {
+		openpower::guard::libguard_init(false);
+		auto records = openpower::guard::getAll();
 
-	auto records = openpower::guard::getAll();
-	if (records.size()) {
-		ipl_log(IPL_INFO, "Number of Records = %d\n",records.size());
+		if (records.size()) {
+			ipl_log(IPL_INFO, "Number of Records = %d\n",
+				records.size());
 
+			if (!ipl_guard()) {
+				// Don't return, we should handle reconfig type
+				// guard records even if guard setting is
+				// disabled.
+				ipl_log(IPL_INFO,
+					"Disabled to apply the guard records");
+			}
 
-		if (!ipl_guard()) {
-			// Don't return, we should handle reconfig type guard records
-			// even if guard setting is disabled.
-			ipl_log(IPL_INFO, "Disabled to apply the guard records");
+			for (const auto &elem : records) {
+
+				if (!ipl_guard() &&
+				    !openpower::guard::isEphemeralType(
+					elem.errType)) {
+					// Disabled to apply the guard records
+					// so should not allow the records to
+					// apply except ephemeral type guard
+					// records.
+					continue;
+				} else if (elem.recordId == GUARD_RESOLVED) {
+					// No need to apply the resolved guard
+					// records.
+					continue;
+				}
+
+				guard_target targetinfo;
+				targetinfo.guardType = elem.errType;
+				int index = 0, i, err;
+
+				targetinfo.path[index] =
+				    elem.targetId.type_size;
+				index += 1;
+
+				for (i = 0;
+				     i < (0x0F & elem.targetId.type_size);
+				     i++) {
+
+					targetinfo.path[index] =
+					    elem.targetId.pathElements[i]
+						.targetType;
+					targetinfo.path[index + 1] =
+					    elem.targetId.pathElements[i]
+						.instance;
+
+					index += sizeof(
+					    elem.targetId.pathElements[0]);
+				}
+
+				// Clear ephemeral type guard records in the
+				// normal ipl.
+				if ((ipl_type() == IPL_TYPE_NORMAL) &&
+				    openpower::guard::isEphemeralType(
+					elem.errType)) {
+					openpower::guard::clear(elem.recordId);
+					targetinfo.set_hwas_state = true;
+				} else {
+					targetinfo.set_hwas_state = false;
+				}
+
+				err = pdbg_target_traverse(
+				    NULL, update_hwas_state_callback,
+				    &targetinfo);
+				if ((err == GUARD_CONTINUE_TGT_TRAVERSAL) ||
+				    (err == GUARD_TGT_NOT_FOUND))
+					ipl_log(
+					    IPL_ERROR,
+					    "Failed to set HWAS state for guard"
+					    " record[ID: %d]\n",
+					    elem.recordId);
+			}
 		}
-
-		for (const auto& elem : records) {
-
-			if(!ipl_guard() &&
-			   !openpower::guard::isEphemeralType(elem.errType)) {
-				// Disabled to apply the guard records so should not allow
-				// the records to apply except ephemeral type guard records.
-				continue;
-			}
-			else if(elem.recordId == GUARD_RESOLVED) {
-				// No need to apply the resolved guard records.
-				continue;
-			}
-
-		  	guard_target targetinfo;
-			targetinfo.guardType = elem.errType;
-			int index = 0, i, err;
-
-			targetinfo.path[index] = elem.targetId.type_size;
-			index += 1;
-
-			for (i = 0; i < (0x0F & elem.targetId.type_size); i++) {
-
-				targetinfo.path[index] = elem.targetId.pathElements[i].targetType;
-				targetinfo.path[index+1] = elem.targetId.pathElements[i].instance;
-
-				index += sizeof(elem.targetId.pathElements[0]);
-			}
-
-			// Clear ephemeral type guard records in the normal ipl.
-			if((ipl_type() == IPL_TYPE_NORMAL) &&
-			    openpower::guard::isEphemeralType(elem.errType)) {
-			  	openpower::guard::clear(elem.recordId);
-			  	targetinfo.set_hwas_state = true;
-			}
-			else {
-			  	targetinfo.set_hwas_state = false;
-			}
-
-			err = pdbg_target_traverse(NULL, update_hwas_state_callback, &targetinfo);
-			if ((err == GUARD_CONTINUE_TGT_TRAVERSAL) || (err == GUARD_TGT_NOT_FOUND))
-				ipl_log(IPL_ERROR,
-					"Failed to set HWAS state for guard"
-					" record[ID: %d]\n",
-					elem.recordId);
-		}
+	} catch (const openpower::guard::exception::GuardException &ex) {
+		// For any exeption related to guard, add the PEL and continue
+		// to boot
+		ipl_log(IPL_ERROR,
+			"Caught the exception %s and continuing to boot "
+			"without processing guard records",
+			ex.what());
+		ipl_error_callback(IPL_ERR_GUARD_PARTITION_ACCESS);
 	}
 }
 


### PR DESCRIPTION
Currently whenever the guard file is empty or does not exist, IPLing is terminated with an exception.

Fix : During ipl0, while trying to initialize the libguard if any guard file related exception is triggered, call the registered callback with IPL_ERR_GUARD_PARTITION_ACCESS to create the according PEL.

Adding the IPL_ERR_GUARD_PARTITION_ACCESS enables us to generate the PEL and "User
Data 1" provides more information regarding the PEL

Tested:
Point to dummy file instead of actual guard file
Using the above error in the ipl callback, able to generate the below PEL {
    "0x50000E0C": {
        "SRC":                  "BD8D300B",
        "Message":              "Guard partition access failure",
        "PLID":                 "0x50000E0C",
        "CreatorID":            "BMC",
        "Subsystem":            "BMC Firmware",
        "Commit Time":          "10/06/2022 12:33:57",
        "Sev":                  "Predictive Error",
        "CompID":               "0x3000"
    }
}
...
...
    "Error Details": {
        "Message":              "Guard partition access failure"
    },
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a
unit",
            "Procedure":        "BMC0001"
        }]
    }
},

...
    "LOG011 2022-10-06 13:03:07": "Istep: updatehwmodel: started\n",
    "LOG012 2022-10-06 13:03:07": "updatehwmodel: Genesis mode boot\n",
    "LOG013 2022-10-06 13:03:07": "Guard file
/var/lib/phosphor-software-manager/hostfw/running/NOFILE is empty",

Signed-off-by: deepakala karthikeyan <deepakala.karthikeyan@ibm.com>
Change-Id: I2b1427832fb124eb0c9172e64eefe1f71accde38