### PR TITLE
libphal: Add method to find if control transitioned to host

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -271,6 +271,15 @@ void putCFAM(struct pdbg_target *proc, const uint32_t addr, const uint32_t val);
  */
 bool isSbeVitalAttnActive(struct pdbg_target *proc);
 
+/**
+ * @brief Check if Hostboot has completed and the control transistioned to Host/PHYP
+ *
+ * @return true when we have moved to PHYP
+ * @return false if there is any error in reading the scom address, 
+ * consider control still in hostboot
+ */
+bool hasControlTransitionedToHost();
+
 } // namespace pdbg
 
 namespace dump

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -280,4 +280,26 @@ bool isSbeVitalAttnActive(struct pdbg_target *proc)
 	return validAttn;
 }
 
+bool hasControlTransitionedToHost()
+{
+  //Read the scratch register to find if the control has moved to phyp (Host)
+  auto pibTarget = pdbg_target_from_path(nullptr, "/proc0/pib");
+
+  uint64_t l_coreScratchRegData = 0xFFFFFFFFFFFFFFFFull;
+  // HB changes the below core scratch reg as one of the last instructions that is run,
+  // so if that is zero then we're in phyp
+  uint64_t l_coreScratchRegAddr = 0x4602F489;
+
+  // Is there any error in reading the scom address, consider control is in hostboot
+  if (pib_read(pibTarget, l_coreScratchRegAddr, &l_coreScratchRegData))
+  {
+    // If unable to read the register, by default consider the control is in hostboot
+    log(level::ERROR, "scom read error: 0x%X", l_coreScratchRegAddr );
+    return false;
+  }
+
+  // If the register reads zero, return control moved to host.
+  return (l_coreScratchRegData == 0);
+}
+
 } // namespace openpower::phal::pdbg


### PR DESCRIPTION
Utilizing the xyz.openbmc_project.State.Host interface to ascertain the host's operational status becomes less accurate when transitioning from hostboot to host. During the period when host is initializing and not yet fully operational, the host state is erroneously presumed to be in hostboot. In situations where host encounters initial boot difficulties, and the watchdog time is hit as the boot up process has not completed within a specific time, this watchdog misinterprets the issue as a problem with hostboot.

To address this, there exists a core scratch register that undergoes an update by hostboot just before transferring control to host. We have devised a method that leverages this register to determine whether the transition to host has already occurred.

By implementing this functionality we can determine which booting subsystem is failed or stopped responding, and the dump can be extracted from the right subsystem.

Tested:
Invoked the method at different stages of ipling and found the status
returned as expected.