### PR TITLE
libphal: Flush libphal traces

### DIFF
--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -568,62 +568,81 @@ static bool update_genesis_hwas_state(void)
 			pdbg_for_each_target(data, proc, child)
 			{
 				// mark targets as non functional in the devtree
-				// if it is marked UNUSED in the MRW. This is a workaround for
-				// handling unused IOHS targets in Bonnell.	
-				if (strcmp(data , "iohs") == 0)
-				{
+				// if it is marked UNUSED in the MRW. This is a
+				// workaround for handling unused IOHS targets
+				// in Bonnell.
+				if (strcmp(data, "iohs") == 0) {
 					ATTR_IOHS_CONFIG_MODE_Type iohs_config;
-					if (!pdbg_target_get_attribute(child,
-						"ATTR_IOHS_CONFIG_MODE",
-						1,
-						1, &iohs_config)) {
-						ipl_log(IPL_ERROR,
-							"Attribute ATTR_IOHS_CONFIG_MODE read failed"
-							" for iohs '%s' \n",
-							pdbg_target_path(child));
+					if (!pdbg_target_get_attribute(
+						child, "ATTR_IOHS_CONFIG_MODE",
+						1, 1, &iohs_config)) {
+						ipl_log(
+						    IPL_ERROR,
+						    "Attribute "
+						    "ATTR_IOHS_CONFIG_MODE "
+						    "read failed"
+						    " for iohs '%s' \n",
+						    pdbg_target_path(child));
 						ipl_plat_procedure_error_handler(
-							IPL_ERR_ATTR_READ_FAIL);
+						    IPL_ERR_ATTR_READ_FAIL);
 						return false;
 					}
-					if (iohs_config == ENUM_ATTR_IOHS_CONFIG_MODE_UNUSED) {
-						ipl_log(IPL_INFO,
-							"iohs(%s) setting to non functional \n",
-						pdbg_target_path(child));
-						if (!set_or_clear_state(child, false)) {
-							ipl_log(IPL_ERROR,
-								"Failed to set HWAS state of "
-								"%s, index %d\n",
-								data, pdbg_target_index(child));
-							ipl_error_callback(IPL_ERR_ATTR_WRITE);
+					if (iohs_config ==
+					    ENUM_ATTR_IOHS_CONFIG_MODE_UNUSED) {
+						ipl_log(
+						    IPL_INFO,
+						    "iohs(%s) setting to non "
+						    "functional \n",
+						    pdbg_target_path(child));
+						if (!set_or_clear_state(
+							child, false)) {
+							ipl_log(
+							    IPL_ERROR,
+							    "Failed to set "
+							    "HWAS state of "
+							    "%s, index %d\n",
+							    data,
+							    pdbg_target_index(
+								child));
+							ipl_error_callback(
+							    IPL_ERR_ATTR_WRITE);
 							return false;
 						}
-					}
-					else
-					{
-						if (!set_or_clear_state(child,
+					} else {
+						if (!set_or_clear_state(
+							child,
 							target_enabled)) {
-							ipl_log(IPL_ERROR,
-								"Failed to set HWAS state of "
-								"%s, index %d\n",
-								data, pdbg_target_index(child));
-							ipl_error_callback(IPL_ERR_ATTR_WRITE);
+							ipl_log(
+							    IPL_ERROR,
+							    "Failed to set "
+							    "HWAS state of "
+							    "%s, index %d\n",
+							    data,
+							    pdbg_target_index(
+								child));
+							ipl_error_callback(
+							    IPL_ERR_ATTR_WRITE);
 							return false;
 						}
 					}
-				} //iohs
+				} // iohs
 				else {
-					if (!set_or_clear_state(child,
-							target_enabled)) {
-						ipl_log(IPL_ERROR,
-							"Failed to set HWAS state of "
-							"%s, index %d\n",
-							data, pdbg_target_index(child));
-						ipl_error_callback(IPL_ERR_ATTR_WRITE);
+					if (!set_or_clear_state(
+						child, target_enabled)) {
+						ipl_log(
+						    IPL_ERROR,
+						    "Failed to set HWAS state "
+						    "of "
+						    "%s, index %d\n",
+						    data,
+						    pdbg_target_index(child));
+						ipl_error_callback(
+						    IPL_ERR_ATTR_WRITE);
 						return false;
 					}
 				}
-			} //foreach
-		} //endfor
+			} // foreach
+		} // endfor
 	}
 
 	pdbg_for_each_class_target("oscrefclk", clock_target)

--- a/libphal/README.md
+++ b/libphal/README.md
@@ -1,8 +1,8 @@
 PHAL(Power Hardware Abstraction Layer) utility library
 
-	Utility library functions for PHAL repository provided APIs.
-This is mainly intended for advanced RAS support for PHAL provided APIs
-in a common place. Also provides c++ wrapper around some of libpdbg
-functionality.
+    Utility library functions for PHAL repository provided APIs.
+
+This is mainly intended for advanced RAS support for PHAL provided APIs in a
+common place. Also provides c++ wrapper around some of libpdbg functionality.
 
 "libphal" feature need to enable to build this library.

--- a/libphal/log.C
+++ b/libphal/log.C
@@ -16,6 +16,7 @@ void log(level logLevel, const char *fmt, ...)
 
 	vfprintf(stdout, fmt, ap);
 	std::cout << "\n";
+	fflush(stdout);
 
 	va_end(ap);
 }

--- a/libphal/phal_exception.C
+++ b/libphal/phal_exception.C
@@ -5,31 +5,29 @@ namespace openpower::phal
 {
 namespace exception
 {
-//taken from error_info_defs.H, including the header file breaks logging and
-//debug collector as they need to include ekb in include path
-enum errlSeverity_t
-{
-	FAPI2_ERRL_SEV_UNDEFINED     = 0x00, /// Used internally by ffdc mechanism
-	FAPI2_ERRL_SEV_RECOVERED     = 0x10, /// Not seen by customer
-	FAPI2_ERRL_SEV_PREDICTIVE    = 0x20, /// Error recovered but customer will see
-	FAPI2_ERRL_SEV_UNRECOVERABLE = 0x40  /// Unrecoverable, general
+// taken from error_info_defs.H, including the header file breaks logging and
+// debug collector as they need to include ekb in include path
+enum errlSeverity_t {
+	FAPI2_ERRL_SEV_UNDEFINED = 0x00, /// Used internally by ffdc mechanism
+	FAPI2_ERRL_SEV_RECOVERED = 0x10, /// Not seen by customer
+	FAPI2_ERRL_SEV_PREDICTIVE =
+	    0x20, /// Error recovered but customer will see
+	FAPI2_ERRL_SEV_UNRECOVERABLE = 0x40 /// Unrecoverable, general
 };
 
 using namespace openpower::phal::logging;
 
 SbeError::SbeError(ERR_TYPE type, int fd, const fs::path fileName) : type(type)
 {
-	ffdcFileList.insert(
-		std::make_pair(DEFAULT_SLID,
-			std::make_tuple(FAPI2_ERRL_SEV_UNRECOVERABLE, fd, fileName)));
+	ffdcFileList.insert(std::make_pair(
+	    DEFAULT_SLID,
+	    std::make_tuple(FAPI2_ERRL_SEV_UNRECOVERABLE, fd, fileName)));
 }
 SbeError::~SbeError()
 {
-	for(const auto& iter : ffdcFileList)
-	{
+	for (const auto& iter : ffdcFileList) {
 		auto tuple = iter.second;
-		if(fs::remove(std::get<2>(tuple)) == false)
-		{
+		if (fs::remove(std::get<2>(tuple)) == false) {
 			// Log error message and exit from destructor
 			log(level::ERROR, "File(%s) remove failed(errnno:%d)",
 			    std::get<2>(tuple), errno);

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -97,8 +97,8 @@ class SbeError final : public phalError
 {
        public:
 	SbeError(ERR_TYPE type, int fd, const fs::path fileName);
-	SbeError(ERR_TYPE type) : type(type){};
-	SbeError() : type(NONE){};
+	SbeError(ERR_TYPE type) : type(type) {};
+	SbeError() : type(NONE) {};
 	SbeError(ERR_TYPE type, const FFDCFileList &fileList) :
 	    type(type), ffdcFileList(fileList)
 	{
@@ -206,13 +206,13 @@ class DumpError final : public phalError
 class PdbgError final : public phalError
 {
        public:
-	PdbgError(ERR_TYPE type) : type(type){};
-	PdbgError() : type(NONE){};
+	PdbgError(ERR_TYPE type) : type(type) {};
+	PdbgError() : type(NONE) {};
 
 	PdbgError &operator=(PdbgError &&) = default;
 	PdbgError(PdbgError &&) = default;
 
-	virtual ~PdbgError(){};
+	virtual ~PdbgError() {};
 
 	/* return error type */
 	ERR_TYPE errType() const noexcept override

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -439,7 +439,7 @@ std::expected<FRUType, phal_exception::ERR_TYPE>
 		return std::unexpected(phal_exception::DEVTREE_ATTR_READ_FAIL);
 	}
 	log(level::ERROR, "Given location code %s is not found ",
-	    unExpandedLocCode);
+	    unExpandedLocCode.c_str());
 	return std::unexpected(phal_exception::ATTR_LOC_CODE_NOT_FOUND);
 }
 } // namespace openpower::phal::pdbg


### PR DESCRIPTION
libphal trace is broken and the traces are not flushed to the journal. So, using fflush to fix this issue.

Also, log() method is expecting a c string. so, type casting the argument.

Change-Id: I61b77f71a02504a86fc144832f6fa2cb1410a21c