### PR TITLE
libphal:Replace error trace with debug trace for getFRUType API calls

### DIFF
--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -438,7 +438,7 @@ std::expected<FRUType, phal_exception::ERR_TYPE>
 				  "target at given location code");
 		return std::unexpected(phal_exception::DEVTREE_ATTR_READ_FAIL);
 	}
-	log(level::ERROR, "Given location code %s is not found ",
+	log(level::DEBUG, "Given location code %s is not found ",
 	    unExpandedLocCode.c_str());
 	return std::unexpected(phal_exception::ATTR_LOC_CODE_NOT_FOUND);
 }


### PR DESCRIPTION
We are modifying the logging behavior for the getFRUType API. Instead of logging an error trace when a location code does not exist in the PHAL device tree, we will now log a debug trace. This change is intended to reduce unnecessary entries in the journal.

Change-Id: I7829f968ec36000f6961c92d5b9a7e8cd961d109