### PR TITLE
ipl-targeting: Transition ipl library to use targeting libraries 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ endif
 if BUILD_P10
 libipl_istep_SOURCES = \
 	libipl/p10/common.C \
+	libipl/p10/ipl_sbe.C \
 	libipl/p10/ipl0.C \
 	libipl/p10/ipl1.C \
 	libipl/p10/ipl2.C \

--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,6 @@ libphal_la_SOURCES = \
 	libphal/libphal.H \
 	libphal/phal_sbe.C \
 	libphal/phal_pdbg.C \
-	libphal/phal_dump.C \
 	error/errl_entry.C \
 	error/errl_factory.C \
 	error/errl_handle.C \

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,14 @@ if test x"$ac_cv_lib_pdbg_pdbg_targets_init" != "xyes" ; then
 	AC_MSG_ERROR([PDBG library not found])
 fi
 
+# --- Dependency checks (replacing pdbg) ---
+PKG_CHECK_MODULES([TARGETING],   [libtargeting])
+PKG_CHECK_MODULES([HWACCESS],    [libhwaccess])
+PKG_CHECK_MODULES([TARGETSVC],   [libtargetsvc])
+
+# Aggregate all dependency cflags/libs
+LIBS="$TARGETING_LIBS $HWACCESS_LIBS $TARGETSVC_LIBS $LIBS"
+
 # Find path to libekb.H
 CPPFLAGS=$CXXFLAGS
 AX_ABSOLUTE_HEADER([libekb.H])

--- a/ipl.C
+++ b/ipl.C
@@ -16,6 +16,8 @@ extern "C" {
 #include <libekb.H>
 #include <libipl/libipl.H>
 
+#include <targeting/target_service.H>
+
 static bool isstring(const char *arg)
 {
 	size_t i;
@@ -188,6 +190,8 @@ int main(int argc, char *const *argv)
 		pdbg_set_backend(backend, device);
 
 	pdbg_set_loglevel(log_level);
+
+    TARGETING::TargetService::instance().init("/tmp/targeting_test.dtb");
 
 	if (!pdbg_targets_init(NULL))
 		exit(1);

--- a/istep0.C
+++ b/istep0.C
@@ -8,8 +8,12 @@ extern "C" {
 #include <libekb.H>
 #include <libipl/libipl.H>
 
+#include <targeting/target_service.H>
+
 int main(void)
 {
+    TARGETING::TargetService::instance().init("/tmp/targeting_test.dtb");
+
 	if (!pdbg_targets_init(NULL))
 		exit(1);
 

--- a/libipl/p10/common.C
+++ b/libipl/p10/common.C
@@ -12,6 +12,14 @@ extern "C" {
 #include <libekb.H>
 #include <error_info_defs.H>
 
+#include <targeting/target_service.H>
+#include <targeting/predicates/predicateattrval.H>
+#include <targeting/predicates/predicateisfunctional.H>
+#include <targeting/predicates/predicatepostfixexpr.H>
+#include <targeting/target.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
+
 #include <ekb/hwpf/fapi2/include/return_code_defs.H>
 #include <ekb/chips/p10/procedures/hwp/istep/p10_do_fw_hb_istep.H>
 #include <ekb/chips/p10/procedures/hwp/sbe/p10_get_sbe_msg_register.H>
@@ -25,9 +33,8 @@ bool ipl_is_master_proc(struct pdbg_target *proc)
 		ipl_log(IPL_ERROR,
 			"Attribute [ATTR_PROC_MASTER_TYPE] read failed \n");
 
-		if (pdbg_target_index(proc) == 0)
+        if (pdbg_target_index(proc) == 0)
 			return true;
-
 		return false;
 	}
 
@@ -36,6 +43,21 @@ bool ipl_is_master_proc(struct pdbg_target *proc)
 		return true;
 
 	return false;
+}
+
+bool ipl_is_master_proc(TARGETING::ConstTargetPtr proc)
+{
+    using namespace TARGETING;
+    AttributeTraits<ATTR_PROC_MASTER_TYPE>::Type val =  PROC_MASTER_TYPE_INVALID;
+
+    if(!proc->tryGetAttr<ATTR_PROC_MASTER_TYPE>(val))
+    {
+        std::cerr << "p12-refactor ipl_is_master_proc: Attribute read failed\n";
+        return false;
+    }
+
+    std::cout << "p12-refactor PROC_MASTER_TYPE: " << static_cast<PROC_MASTER_TYPE>(val) << std::endl;
+    return (static_cast<PROC_MASTER_TYPE>(val) == PROC_MASTER_TYPE_ACTING_MASTER);
 }
 
 int ipl_istep_via_sbe(int major, int minor)
@@ -200,6 +222,20 @@ bool ipl_is_present(struct pdbg_target *target)
 	return (buf[4] & 0x40);
 }
 
+bool ipl_is_present(TARGETING::ConstTargetPtr target)
+{
+    using namespace TARGETING;
+    AttributeTraits<ATTR_HWAS_STATE>::Type hwas{};
+
+    if(!target->tryGetAttr<ATTR_HWAS_STATE>(hwas))
+    {
+        std::cout << "p12-refactor ipl_is_present: Attribute read failed\n";
+        return false;
+    }
+
+    return static_cast<bool>(hwas.present);
+}
+
 bool ipl_is_functional(struct pdbg_target *target)
 {
 	uint8_t buf[5];
@@ -220,6 +256,20 @@ bool ipl_is_functional(struct pdbg_target *target)
 	return (buf[4] & 0x20);
 }
 
+bool ipl_is_functional(TARGETING::ConstTargetPtr target)
+{
+    using namespace TARGETING;
+    AttributeTraits<ATTR_HWAS_STATE>::Type hwas{};
+
+    if(!target->tryGetAttr<ATTR_HWAS_STATE>(hwas))
+    {
+        std::cout << "p12-refactor ipl_is_functional: Attribute read failed\n";
+        return false;
+    }
+
+    return static_cast<bool>(hwas.functional);
+}
+
 bool ipl_check_functional_master(void)
 {
 	struct pdbg_target *proc;
@@ -238,6 +288,42 @@ bool ipl_check_functional_master(void)
 	}
 
 	return true;
+}
+
+TARGETING::TargetPtr getFunctionalMasterProc(void)
+{
+    using namespace TARGETING;
+
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
+
+    auto isFunctional = std::make_shared<PredicateIsFunctional>();
+    auto typeProc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC);
+    auto masterProc = std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(
+        0); // 0 = master proc
+
+    PredicatePostfixExpr masterFuncProcPred;
+    masterFuncProcPred.push(typeProc).push(masterProc).And()
+                      .push(isFunctional).And();
+
+    auto targets = ts.getAssociated(top, AssociationType::childByPhysical,
+                                    RecursionLevel::all, &masterFuncProcPred);
+    if (targets.empty())
+    {
+        std::cerr << "p12-refactor: functional master proc not found" << std::endl;
+        return nullptr;
+    }
+
+    if (targets.size() != 1)
+    {
+        std::cerr << "p12-refactor: Functional master procs Expected: 1 Found: "
+                  << targets.size() << std::endl;
+        return nullptr;
+    }
+
+    std::cout << "p12-refactor: getFunctionalMasterProc returning target" << std::endl;
+
+    return targets.front();
 }
 
 struct pdbg_target *ipl_get_functional_primary_proc(void)

--- a/libipl/p10/common.C
+++ b/libipl/p10/common.C
@@ -85,13 +85,14 @@ int ipl_istep_via_sbe(int major, int minor)
 	return rc;
 }
 
-int ipl_istep_via_hostboot(int major, int minor)
+[[maybe_unused]] int ipl_istep_via_hostboot(int /*major*/, int /*minor*/)
 {
+    /* TODO p12-refactor
 	struct pdbg_target *proc;
-	uint64_t retry_limit_ms = 30 * 60 * 1000;
-	uint64_t delay_ms = 100;
+    uint64_t retry_limit_ms = 30 * 60 * 1000;
+	uint64_t delay_ms = 100;*/
 	int rc = 1;
-
+    /*
 	ipl_log(IPL_INFO, "Istep: Hostboot %d.%d : started\n", major, minor);
 
 	pdbg_for_each_class_target("proc", proc)
@@ -114,8 +115,9 @@ int ipl_istep_via_hostboot(int major, int minor)
 			"Running p10_do_fw_hb_istep HWP on processor %d\n",
 			pdbg_target_index(proc));
 
-		fapi_rc = p10_do_fw_hb_istep(proc, major, minor, retry_limit_ms,
+        fapi_rc = p10_do_fw_hb_istep(proc, major, minor, retry_limit_ms,
 					     delay_ms);
+
 		if (fapi_rc != fapi2::FAPI2_RC_SUCCESS)
 			ipl_log(IPL_ERROR,
 				"Istep %d.%d failed on chip %d, rc=%d\n", major,
@@ -126,13 +128,14 @@ int ipl_istep_via_hostboot(int major, int minor)
 		ipl_error_callback((rc == 0) ? IPL_ERR_OK : IPL_ERR_HWP);
 		break;
 	}
-
+*/
 	return rc;
 }
 
-bool ipl_sbe_booted(struct pdbg_target *proc, uint32_t wait_time_seconds)
+[[maybe_unused]] bool ipl_sbe_booted(struct pdbg_target * /*proc*/, uint32_t /*wait_time_seconds*/)
 {
-	sbeMsgReg_t sbeReg;
+    //TODO p12-refactor
+	/*sbeMsgReg_t sbeReg;
 	fapi2::ReturnCode fapi_rc;
 	uint32_t loopcount;
 
@@ -175,7 +178,7 @@ bool ipl_sbe_booted(struct pdbg_target *proc, uint32_t wait_time_seconds)
 		}
 	}
 	ipl_log(IPL_ERROR, "SBE Debug Data: 0x2809[0x%08x]  0x1007[0x%08x] \n",
-		uint32_t(sbeReg.reg), val);
+		uint32_t(sbeReg.reg), val);*/
 	return false;
 }
 
@@ -346,8 +349,8 @@ int ipl_set_sbe_state_all_sec(enum sbe_state state)
 	return ret;
 }
 
-void ipl_process_fapi_error(const fapi2::ReturnCode &fapirc,
-			    struct pdbg_target *target, bool deconfig)
+[[maybe_unused]] void ipl_process_fapi_error(const fapi2::ReturnCode &fapirc,
+			    struct pdbg_target * target, bool deconfig)
 {
 	if (fapirc == fapi2::FAPI2_RC_SUCCESS) {
 		ipl_error_callback(IPL_ERR_OK);

--- a/libipl/p10/common.C
+++ b/libipl/p10/common.C
@@ -45,21 +45,6 @@ bool ipl_is_master_proc(struct pdbg_target *proc)
 	return false;
 }
 
-bool ipl_is_master_proc(TARGETING::ConstTargetPtr proc)
-{
-    using namespace TARGETING;
-    AttributeTraits<ATTR_PROC_MASTER_TYPE>::Type val =  PROC_MASTER_TYPE_INVALID;
-
-    if(!proc->tryGetAttr<ATTR_PROC_MASTER_TYPE>(val))
-    {
-        std::cerr << "p12-refactor ipl_is_master_proc: Attribute read failed\n";
-        return false;
-    }
-
-    std::cout << "p12-refactor PROC_MASTER_TYPE: " << static_cast<PROC_MASTER_TYPE>(val) << std::endl;
-    return (static_cast<PROC_MASTER_TYPE>(val) == PROC_MASTER_TYPE_ACTING_MASTER);
-}
-
 int ipl_istep_via_sbe(int major, int minor)
 {
 	struct pdbg_target *pib, *proc;
@@ -109,12 +94,12 @@ int ipl_istep_via_sbe(int major, int minor)
 
 [[maybe_unused]] int ipl_istep_via_hostboot(int /*major*/, int /*minor*/)
 {
-    /* TODO p12-refactor
+    /* TODO phal-refactor
 	struct pdbg_target *proc;
     uint64_t retry_limit_ms = 30 * 60 * 1000;
-	uint64_t delay_ms = 100;*/
+	uint64_t delay_ms = 100;
 	int rc = 1;
-    /*
+    
 	ipl_log(IPL_INFO, "Istep: Hostboot %d.%d : started\n", major, minor);
 
 	pdbg_for_each_class_target("proc", proc)
@@ -150,13 +135,13 @@ int ipl_istep_via_sbe(int major, int minor)
 		ipl_error_callback((rc == 0) ? IPL_ERR_OK : IPL_ERR_HWP);
 		break;
 	}
-*/
-	return rc;
+	return rc;*/
+    return 1;
 }
 
 [[maybe_unused]] bool ipl_sbe_booted(struct pdbg_target * /*proc*/, uint32_t /*wait_time_seconds*/)
 {
-    //TODO p12-refactor
+    //TODO phal-refactor
 	/*sbeMsgReg_t sbeReg;
 	fapi2::ReturnCode fapi_rc;
 	uint32_t loopcount;
@@ -229,7 +214,7 @@ bool ipl_is_present(TARGETING::ConstTargetPtr target)
 
     if(!target->tryGetAttr<ATTR_HWAS_STATE>(hwas))
     {
-        std::cout << "p12-refactor ipl_is_present: Attribute read failed\n";
+        std::cout << "phal-refactor ipl_is_present: Attribute read failed\n";
         return false;
     }
 
@@ -254,20 +239,6 @@ bool ipl_is_functional(struct pdbg_target *target)
 	// isFuntional bit is stored in 4th byte and bit 3 position in
 	// HWAS_STATE
 	return (buf[4] & 0x20);
-}
-
-bool ipl_is_functional(TARGETING::ConstTargetPtr target)
-{
-    using namespace TARGETING;
-    AttributeTraits<ATTR_HWAS_STATE>::Type hwas{};
-
-    if(!target->tryGetAttr<ATTR_HWAS_STATE>(hwas))
-    {
-        std::cout << "p12-refactor ipl_is_functional: Attribute read failed\n";
-        return false;
-    }
-
-    return static_cast<bool>(hwas.functional);
 }
 
 bool ipl_check_functional_master(void)
@@ -310,18 +281,18 @@ TARGETING::TargetPtr getFunctionalMasterProc(void)
                                     RecursionLevel::all, &masterFuncProcPred);
     if (targets.empty())
     {
-        std::cerr << "p12-refactor: functional master proc not found" << std::endl;
+        std::cerr << "phal-refactor functional master proc not found" << std::endl;
         return nullptr;
     }
 
     if (targets.size() != 1)
     {
-        std::cerr << "p12-refactor: Functional master procs Expected: 1 Found: "
+        std::cerr << "phal-refactor Functional master procs Expected: 1 Found: "
                   << targets.size() << std::endl;
         return nullptr;
     }
 
-    std::cout << "p12-refactor: getFunctionalMasterProc returning target" << std::endl;
+    //std::cout << "phal-refactor Functional MasterProc found" << std::endl;
 
     return targets.front();
 }

--- a/libipl/p10/common.H
+++ b/libipl/p10/common.H
@@ -46,6 +46,7 @@ bool ipl_is_present(TARGETING::ConstTargetPtr target);
  * @return true if the target is functional, false otherwise
  */
 bool ipl_is_functional(struct pdbg_target *target);
+bool ipl_is_functional(TARGETING::ConstTargetPtr target);
 TARGETING::TargetPtr getFunctionalMasterProc(void);
 /**
  * @brief Check if functional master processor is available.

--- a/libipl/p10/common.H
+++ b/libipl/p10/common.H
@@ -14,7 +14,6 @@ extern "C" {
 #define NUM_CLOCK_FOR_REDUNDANT_MODE 2
 
 bool ipl_is_master_proc(struct pdbg_target *proc);
-bool ipl_is_master_proc(TARGETING::ConstTargetPtr proc);
 int ipl_istep_via_sbe(int major, int minor);
 int ipl_istep_via_hostboot(int major, int minor);
 
@@ -46,7 +45,6 @@ bool ipl_is_present(TARGETING::ConstTargetPtr target);
  * @return true if the target is functional, false otherwise
  */
 bool ipl_is_functional(struct pdbg_target *target);
-bool ipl_is_functional(TARGETING::ConstTargetPtr target);
 TARGETING::TargetPtr getFunctionalMasterProc(void);
 /**
  * @brief Check if functional master processor is available.

--- a/libipl/p10/common.H
+++ b/libipl/p10/common.H
@@ -7,11 +7,14 @@ extern "C" {
 #include <libpdbg_sbe.h>
 }
 
+#include <targeting/target.H>
+#include <targeting/target_service.H>
 #include <ekb/hwpf/fapi2/include/return_code.H>
 
 #define NUM_CLOCK_FOR_REDUNDANT_MODE 2
 
 bool ipl_is_master_proc(struct pdbg_target *proc);
+bool ipl_is_master_proc(TARGETING::ConstTargetPtr proc);
 int ipl_istep_via_sbe(int major, int minor);
 int ipl_istep_via_hostboot(int major, int minor);
 
@@ -34,6 +37,7 @@ bool ipl_sbe_booted(struct pdbg_target *proc, uint32_t wait_time_seconds);
  */
 
 bool ipl_is_present(struct pdbg_target *target);
+bool ipl_is_present(TARGETING::ConstTargetPtr target);
 /**
  * @brief Determine whether the target is functional or not
  *
@@ -42,7 +46,7 @@ bool ipl_is_present(struct pdbg_target *target);
  * @return true if the target is functional, false otherwise
  */
 bool ipl_is_functional(struct pdbg_target *target);
-
+TARGETING::TargetPtr getFunctionalMasterProc(void);
 /**
  * @brief Check if functional master processor is available.
  *

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -11,6 +11,7 @@ extern "C" {
 #include "libipl.H"
 #include "libipl_internal.H"
 #include "common.H"
+#include "ipl_sbe.H"
 #include <attributes_info.H>
 
 #include <ekb/chips/p10/procedures/hwp/perv/p10_start_cbs.H>
@@ -18,6 +19,14 @@ extern "C" {
 #include <ekb/chips/p10/procedures/hwp/perv/p10_clock_test.H>
 #include <ekb/chips/p10/procedures/hwp/perv/p10_setup_sbe_config.H>
 #include <ekb/chips/p10/procedures/hwp/perv/p10_select_boot_master.H>
+
+#include <targeting/target_service.H>
+#include <targeting/predicates/predicateattrval.H>
+#include <targeting/predicates/predicateisfunctional.H>
+#include <targeting/predicates/predicatepostfixexpr.H>
+#include <targeting/target.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
 
 #include <libguard/guard_interface.hpp>
 #include <libguard/guard_entity.hpp>
@@ -128,6 +137,34 @@ static bool set_or_clear_state(struct pdbg_target *target, bool do_set)
 	return true;
 }
 
+static bool set_or_clear_state(TARGETING::TargetPtr target, bool do_set)
+{
+    using namespace TARGETING;
+
+    AttributeTraits<ATTR_HWAS_STATE>::Type hwas;
+    if(!target->tryGetAttr<ATTR_HWAS_STATE>(hwas))
+    {
+        std::cerr << "p12-refactor set_or_clear_state Attribute read failed\n";
+		return false;
+    }
+    
+    hwas.functional = 0;
+   
+    if(do_set)
+    {
+        hwas.present = 1;
+        hwas.functional = 1;
+    }
+
+    if(!target->trySetAttr<ATTR_HWAS_STATE>(hwas))
+    {
+        std::cerr << "p12-refactor set_or_clear_state Attribute write failed\n";
+		return false;
+    }
+
+    return true;
+}
+
 /*
  * Helper function set the clock functional state based on
  * ATTR_SYS_CLOCK_DECONFIG_STATE values
@@ -139,75 +176,95 @@ static bool set_or_clear_state(struct pdbg_target *target, bool do_set)
  */
 static bool update_clock_func_state(void)
 {
+	using namespace TARGETING;
+
 	ipl_log(
 	    IPL_INFO,
 	    "Updating ref clock target HWAS state based on Hostboot value \n");
 
-	ATTR_SYS_CLOCK_DECONFIG_STATE_Type clk_state =
-	    ENUM_ATTR_SYS_CLOCK_DECONFIG_STATE_NO_DECONFIG;
+    AttributeTraits<ATTR_SYS_CLOCK_DECONFIG_STATE>::Type clk_state =
+                        SYS_CLOCK_DECONFIG_STATE_NO_DECONFIG;
 
-	struct pdbg_target *clock_target;
-	struct pdbg_target *root = pdbg_target_root();
-	if (!pdbg_target_get_attribute(root, "ATTR_SYS_CLOCK_DECONFIG_STATE", 4,
-				       1, &clk_state)) {
-		ipl_log(
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
+
+    if(!top->tryGetAttr<ATTR_SYS_CLOCK_DECONFIG_STATE>(clk_state))
+    {
+        std::cout << "p12-refactor trygetattr failed ATTR_SYS_CLOCK_DECONFIG_STATE\n";
+        ipl_log(
 		    IPL_ERROR,
 		    "Attribute [ATTR_SYS_CLOCK_DECONFIG_STATE] read failed \n");
-		ipl_plat_procedure_error_handler(IPL_ERR_ATTR_READ_FAIL);
-		return false;
-	}
+		//ipl_plat_procedure_error_handler(IPL_ERR_ATTR_READ_FAIL);
+		//return false;
+    }
 
-	if (clk_state == ENUM_ATTR_SYS_CLOCK_DECONFIG_STATE_NO_DECONFIG) {
+	if (clk_state == SYS_CLOCK_DECONFIG_STATE_NO_DECONFIG)
+    {
 		// No HWAS state update required
 		ipl_log(IPL_INFO, "update_clock_func_state : No updates \n");
 		return true;
 	}
-	pdbg_for_each_class_target("oscrefclk", clock_target)
-	{
-		if (clk_state ==
-		    ENUM_ATTR_SYS_CLOCK_DECONFIG_STATE_ALL_DECONFIG) {
+
+    PredicateAttrVal<ATTR_TYPE> pred(TYPE_OSCREFCLK);
+
+    for (auto&& clock_target :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred))
+    {
+        if (clk_state == SYS_CLOCK_DECONFIG_STATE_ALL_DECONFIG)
+        {
 			// Update HWAS state to non-functional
-			ipl_log(IPL_INFO,
+			/*TODO ipl_log(IPL_INFO,
 				"Clock(%s) setting to non functional \n",
-				pdbg_target_path(clock_target));
-			if (!set_or_clear_state(clock_target, false)) {
-				return false;
+				pdbg_target_path(clock_target));*/
+			if (!set_or_clear_state(clock_target, false))
+            {
+                std::cout << "p12-refactor setorclearstate-1 failed\n";
+				//return false;
 			}
 			continue;
 		}
-		// Get Clock position
-		ATTR_POSITION_Type clk_pos;
-		if (!pdbg_target_get_attribute(clock_target, "ATTR_POSITION", 2,
-					       1, &clk_pos)) {
-			ipl_log(IPL_ERROR,
-				"Attribute ATTR_POSITION read failed"
-				" for clock '%s' \n",
-				pdbg_target_path(clock_target));
-			ipl_plat_procedure_error_handler(
-			    IPL_ERR_ATTR_READ_FAIL);
-			return false;
-		}
-		// Assumption: Clock A linked to ATTR_POSITION value 0 and
+
+        // Get Clock position
+        AttributeTraits<ATTR_POSITION>::Type clk_pos;
+
+        if(!clock_target->tryGetAttr<ATTR_POSITION>(clk_pos))
+        {
+            std::cout << "p12-refactor trygetattr failed ATTR_POSITION\n";
+            /*TODO ipl_log(IPL_ERROR, "Attribute ATTR_POSITION read failed"
+                    " for clock '%s' \n", pdbg_target_path(clock_target));*/
+
+            //ipl_plat_procedure_error_handler(IPL_ERR_ATTR_READ_FAIL);
+
+            //return false;
+        }
+
+        // Assumption: Clock A linked to ATTR_POSITION value 0 and
 		// Clock B linked to ATTR_POSITION value 1
-		if (((clk_pos == 0) &&
-		     (clk_state ==
-		      ENUM_ATTR_SYS_CLOCK_DECONFIG_STATE_A_DECONFIG)) ||
-		    ((clk_pos == 1) &&
-		     (clk_state ==
-		      ENUM_ATTR_SYS_CLOCK_DECONFIG_STATE_B_DECONFIG))) {
-			ipl_log(IPL_INFO,
+        const bool deconfigClkA = ((clk_pos == 0) &&
+		             (clk_state == SYS_CLOCK_DECONFIG_STATE_A_DECONFIG)) ;
+
+        const bool deconfigClkB = ((clk_pos == 1) &&
+                     (clk_state == SYS_CLOCK_DECONFIG_STATE_B_DECONFIG));
+
+        if (deconfigClkA || deconfigClkB)
+		{
+			/*TODO ipl_log(IPL_INFO,
 				"deconfig state(%d) Clock(%s) setting to non "
 				"functional \n",
-				clk_state, pdbg_target_path(clock_target));
-			if (!set_or_clear_state(clock_target, false)) {
-				return false;
+				clk_state, pdbg_target_path(clock_target));*/
+
+			if (!set_or_clear_state(clock_target, false))
+            {
+                std::cout << "p12-refactor setorclearstate-2 failed\n";
+				//TODO return false;
 			}
 		}
-	}
+    }
 	return true;
 }
 
-static int update_hwas_state_callback(struct pdbg_target *target, void *priv)
+[[maybe_unused]] static int update_hwas_state_callback(struct pdbg_target *target, void *priv)
 {
 	guard_target *target_info = static_cast<guard_target *>(priv);
 	uint8_t path[21] = {0};
@@ -359,7 +416,7 @@ static int update_hwas_state_callback(struct pdbg_target *target, void *priv)
  *   in the PowerOn or TI or Checkstop or Watchdog timeout path) is exist
  *   in the current boot.
  */
-static bool guard_action_allowed()
+[[maybe_unused]] static bool guard_action_allowed()
 {
 	if (ipl_type() == IPL_TYPE_MPIPL) {
 		return true;
@@ -381,7 +438,7 @@ static bool guard_action_allowed()
 //@Brief Function will get the guard records and will update the functional
 // state of the guarded resources in HWAS state attribute in device tree based
 // on the guard actions in the different boots.
-static void process_guard_records()
+[[maybe_unused]] static void process_guard_records()
 {
 	if (!guard_action_allowed()) {
 		ipl_log(IPL_INFO, "No guard actions in the current boot");
@@ -486,47 +543,54 @@ static void process_guard_records()
  */
 static void apply_fco_override(void)
 {
-	std::array<const char *, 8> mProcChild = {
-	    "core", "pauc", "pau", "iohs", "mc", "chiplet", "pec", "fc"};
-	struct pdbg_target *proc, *child;
-	uint8_t buf[5];
+    using namespace TARGETING;
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
 
-	pdbg_for_each_class_target("proc", proc)
-	{
-		if (!ipl_is_master_proc(proc))
-			continue;
+    auto typeProc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC);
+    auto masterProc = std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0);
+    PredicatePostfixExpr masterFuncProcPred;
+    masterFuncProcPred.push(typeProc).push(masterProc).And();
+   
+    auto isMc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_MC);
+    auto isCore = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_CORE);
+    auto isPauc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAUC);
+    auto isPau = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAU);
+    auto isIohs = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_IOHS);
+    auto isPec = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PEC);
+    auto isFc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_FC);
 
-		for (const char *data : mProcChild) {
-			pdbg_for_each_target(data, proc, child)
-			{
+    PredicatePostfixExpr expr;
+    expr.push(isMc).push(isCore).Or()
+        .push(isPauc).push(isPau).Or()
+        .push(isIohs).push(isPec).Or()
+        .push(isFc).Or();
 
-				if (!pdbg_target_get_attribute_packed(
-					child, "ATTR_HWAS_STATE", "41", 1,
-					buf)) {
-					ipl_error_callback(
-					    IPL_ERR_ATTR_READ_FAIL);
-					continue;
-				}
+    auto proc_targets = ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &masterFuncProcPred);
+ 
+    if(proc_targets.empty() || (proc_targets.size() != 1))
+    {
+        std::cerr << "p12-refactor apply_fco_override: invalid master proc count\n";
+        return;
+    }
 
-				// 0-1 bits reserved
-				// 2nd bit Functional override
-				// 3rd bit spec deconfig
-				// 4th bit Dump capable
-				// 5th bit Functional
-				// 6th bit Present
-				// 7th bit Deconfig
-				// Checking the FCO bit is set or not. If it's
-				// set means functional and present state of
-				// target should be set.
-				if (buf[4] & 0x04) {
-					if (!set_or_clear_state(child, true)) {
-						ipl_error_callback(
-						    IPL_ERR_ATTR_WRITE);
-					}
-				}
-			}
-		}
-	}
+    for (auto&& pchild :
+            ts.getAssociated(proc_targets.front(), AssociationType::childByPhysical,
+                             RecursionLevel::all, &expr))
+    {
+        auto hwas = pchild->getAttr<ATTR_HWAS_STATE>();
+
+        if(hwas.functionalOverride)
+        {
+            hwas.present = 1;
+            hwas.functional = 1;
+            if(!pchild->trySetAttr<ATTR_HWAS_STATE>(hwas))
+            {
+               std::cerr << "p12-refactor apply_fco_override Attribute write failed\n";
+            }
+        }
+    }
 }
 
 //@Brief Function will set the functional and present state of master proc
@@ -536,6 +600,7 @@ static void apply_fco_override(void)
 // It will also update functional state oscrefclk target.
 static bool update_genesis_hwas_state(void)
 {
+    /* TODO p12-refactor
 	std::array<const char *, 8> mProcChild = {
 	    "core", "pauc", "pau", "iohs", "mc", "chiplet", "pec", "fc"};
 	struct pdbg_target *proc, *child, *clock_target;
@@ -666,58 +731,89 @@ static bool update_genesis_hwas_state(void)
 		}
 	}
 
-	return true;
-}
+	return true;*/
 
-/**
- * @brief Wrapper function to execute continue mpipl on the proc
- *
- * @param[in] proc proc target to operate on
- *
- * return ipl error type enum
- */
-static ipl_error_type ipl_sbe_mpipl_continue(struct pdbg_target *proc)
-{
-	enum sbe_state state;
-	char path[16];
-	int ret = 0;
+    #if 0 //TODO p12-refactor
+    using namespace TARGETING;
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
 
-	ipl_log(IPL_INFO, "ipl_sbe_mpipl_continue: Enter(%s)",
-		pdbg_target_path(proc));
+    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
 
-	// get PIB target
-	sprintf(path, "/proc%d/pib", pdbg_target_index(proc));
-	struct pdbg_target *pib = pdbg_target_from_path(nullptr, path);
-	if (pib == nullptr) {
-		ipl_log(IPL_ERROR, "Failed to get PIB target for(%s)",
-			pdbg_target_path(proc));
-		return IPL_ERR_PIB_TGT_NOT_FOUND;
-	}
+    auto isMc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_MC);
+    auto isCore = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_CORE);
+    auto isPauc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAUC);
+    auto isPau = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAU);
+    auto isIohs = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_IOHS);
+    auto isPec = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PEC);
+    auto isFc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_FC);
 
-	ret = sbe_get_state(pib, &state);
-	if (ret != 0) {
-		ipl_log(IPL_ERROR, "Failed to read SBE state information (%s)",
-			pdbg_target_path(pib));
-		return IPL_ERR_FSI_REG;
-	}
+    PredicatePostfixExpr expr;
+    expr.push(isMc).push(isCore).push(isPauc).push(isPau)
+        .push(isIohs).push(isPec).push(isFc).Or();
 
-	// SBE_STATE_CHECK_CFAM case is already handled by pdbg api
-	if (state != SBE_STATE_BOOTED) {
-		ipl_log(IPL_ERROR,
-			"SBE (%s) is not ready for chip-op: state(0x%08x)",
-			pdbg_target_path(pib), state);
-		return IPL_ERR_SBE_CHIPOP;
-	}
+    for (auto&& proc :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred))
+    {
+		if (!set_or_clear_state(proc, true))
+        {
+            std::cout << "DEMO: failed to set proc hwas state\n";
+			/*TODO ipl_log(IPL_ERROR,
+				"Failed to set HWAS state of proc %d\n",
+				pdbg_target_index(proc));
+			ipl_error_callback(IPL_ERR_ATTR_WRITE);*/
+			return false;
+		}
 
-	// call pdbg back-end function
-	ret = sbe_mpipl_continue(pib);
-	if (ret != 0) {
-		ipl_log(IPL_ERROR, "SBE (%s) mpipl continue chip-op failed",
-			pdbg_target_path(pib));
-		return IPL_ERR_SBE_CHIPOP;
-	}
+        if(!ipl_is_master_proc(proc))
+                continue;
 
-	return IPL_ERR_OK;
+        for (auto&& pchild :
+                ts.getAssociated(top, AssociationType::childByPhysical,
+                                 RecursionLevel::all, &expr))
+        {
+            if (!set_or_clear_state(pchild,true))
+            {
+                /*TODO ipl_log(IPL_ERROR,
+                    "Failed to set HWAS state of "
+                    "%s, index %d\n",
+                    data, pdbg_target_index(child));
+                ipl_error_callback(IPL_ERR_ATTR_WRITE);*/
+                return false;
+			}
+        }
+    }
+
+    PredicateAttrVal<ATTR_TYPE> clkpred(TYPE_OSCREFCLK);
+
+    for (auto&& clock_target :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &clkpred))
+    {
+        // Get Clock position
+        AttributeTraits<ATTR_POSITION>::Type clk_pos;
+
+        if(!clock_target->tryGetAttr<ATTR_POSITION>(clk_pos))
+        {
+
+            std::cout << "DEMO trygetattr failed to get clock's ATTR_POSITION\n";
+            /*TODO ipl_log(IPL_ERROR, "Attribute ATTR_POSITION read failed"
+                    " for clock '%s' \n", pdbg_target_path(clock_target));*/
+
+            //ipl_plat_procedure_error_handler(IPL_ERR_ATTR_READ_FAIL);
+
+            return false;
+        }
+
+        if (!set_or_clear_state(clock_target, true))
+        {
+            std::cout << "DEMO failed to set clock as functional \n";
+            return false;
+        }
+    }
+#endif
+    return true;
 }
 
 static int ipl_updatehwmodel(void)
@@ -727,7 +823,7 @@ static int ipl_updatehwmodel(void)
 	constexpr auto GENESIS_BOOT_FILE = "/var/lib/phal/genesisboot";
 	fs::path genesis_boot_file = GENESIS_BOOT_FILE;
 
-	ipl_log(IPL_INFO, "Istep: updatehwmodel: started\n");
+    std::cout << "p12-refactor istep0-updatehwmodel: started\n";
 
 	if (!fs::exists(genesis_boot_file)) {
 		ipl_log(IPL_INFO, "updatehwmodel: Genesis mode boot\n");
@@ -750,31 +846,35 @@ static int ipl_updatehwmodel(void)
 		std::ofstream file(GENESIS_BOOT_FILE);
 	}
 
+
 	if ((ipl_type() == IPL_TYPE_MPIPL) ||
 	    (!fs::exists(BOOTTIME_GUARD_INDICATOR)))
-		apply_fco_override();
+            apply_fco_override();
 
-	process_guard_records();
+	//TODO process_guard_records();
 
-	if (!boot_file_absent && (ipl_type() != IPL_TYPE_MPIPL)) {
+	if (!boot_file_absent && (ipl_type() != IPL_TYPE_MPIPL))
+    {
 		// Update SBE state to Not usable in reboot path(not on MPIPL)
 		// Boot error callback is only required for failure
-		ipl_set_sbe_state_all(SBE_STATE_NOT_USABLE);
+		ipl_set_sbe_state_all(ipl::sbe::SBE_STATE_NOT_USABLE);
 
 		// update refclock targets  functional sate based on
 		// SYS_CLOCK_DECONFIG_STATE values.
-		if (!update_clock_func_state()) {
-			ipl_log(IPL_ERROR, "Failed to update set-ref clock "
-					   "functional state \n");
-			return 1;
+		if (!update_clock_func_state())
+        {
+            std::cout << "p12-refactor ipl0-updatehwmodel: updateclockfuncstate failed\n";
 		}
 	}
 
-	if (!ipl_check_functional_master()) {
+	if (getFunctionalMasterProc() == nullptr)
+    {
+        std::cout << "p12-refactor istep0-updatehwmodel: no functional master\n";
 		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
+    std::cout << "p12-refactor istep0-updatehwmodel: done\n";
 	return 0;
 }
 
@@ -821,7 +921,7 @@ static bool skip_clock_reset()
  *
  * @return 0 on success, 1 on failure
  */
-static int initialize_and_check_clock_chip(uint8_t &clock_select)
+[[maybe_unused]] static int initialize_and_check_clock_chip(uint8_t &clock_select)
 {
 	struct pdbg_target *clock_target;
 	enum pdbg_target_status status;
@@ -984,85 +1084,117 @@ static int initialize_and_check_clock_chip(uint8_t &clock_select)
 
 static int ipl_set_ref_clock(void)
 {
-	struct pdbg_target *proc;
 	int rc = 0;
+try{
+    using namespace TARGETING;
 	fapi2::ReturnCode fapirc;
-	// Default value of attribute will be for non-redundant mode
-	fapi2::ATTR_CP_REFCLOCK_SELECT_Type clock_select =
-	    ENUM_ATTR_CP_REFCLOCK_SELECT_OSC0;
 
 	if (ipl_type() == IPL_TYPE_MPIPL)
 		return -1;
 
-	ipl_log(IPL_INFO, "Istep: set_ref_clock: started\n");
+    std::cout << "p12-refactor istep0-set_ref_clock: started\n";
 
-	proc = ipl_get_functional_primary_proc();
-	if (proc == NULL) {
-		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
+    TargetPtr proc = getFunctionalMasterProc();
+
+	if (proc == nullptr)
+    {
+        std::cout << "p12-refactor istep0-set_ref_clock: proc is nullptr\n";
+		//ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
+/*TODO p12-refactor
 	if (initialize_and_check_clock_chip(clock_select)) {
 		ipl_log(IPL_ERROR, "Clock initialization failed\n");
 		return 1;
 	}
-
+*/
 	// Update clock select mode value.
-	if (!pdbg_target_set_attribute(proc, "ATTR_CP_REFCLOCK_SELECT", 1, 1,
-				       &clock_select)) {
-		ipl_log(IPL_ERROR,
+    // Default value of attribute will be for non-redundant mode
+    AttributeTraits<ATTR_CP_REFCLOCK_SELECT>::Type
+                            clock_select = CP_REFCLOCK_SELECT_OSC0;
+
+    if(!proc->trySetAttr<ATTR_CP_REFCLOCK_SELECT>(clock_select))
+    {
+        std::cout << "p12-refactor istep0- set_ref_clock: trysetattr failed ATTR_CP_REFCLOCK_SELECT\n";
+		/*TODO ipl_log(IPL_ERROR,
 			"Attribute CP_REFCLOCK_SELECT update failed"
 			" for proc %d \n",
-			pdbg_target_index(proc));
-		ipl_plat_procedure_error_handler(IPL_ERR_ATTR_WRITE);
-		rc++;
-		return 1;
-	}
+			pdbg_target_index(proc));*/
+		//ipl_plat_procedure_error_handler(IPL_ERR_ATTR_WRITE);
+		//rc++;
+		//return 1;
+    }
 
-	ipl_log(IPL_INFO,
+	/*TODO ipl_log(IPL_INFO,
 		"Running p10_setup_ref_clock HWP on primary processor %d\n",
-		pdbg_target_index(proc));
+		pdbg_target_index(proc));*/
+    std::cout << "p12-refactor: executing HWP-p10_setup_ref_clock\n";
 	fapirc = p10_setup_ref_clock(proc);
-	if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
-		ipl_log(IPL_ERROR,
-			"Istep set_ref_clock failed on chip %s, rc=%d \n",
-			pdbg_target_path(proc), fapirc);
-		rc++;
-	}
+    std::cout << "p12-refactor: executing HWP-p10_setup_ref_clock done\n";
 
-	ipl_process_fapi_error(fapirc, proc);
-	return rc;
+    if (fapirc != fapi2::FAPI2_RC_SUCCESS)
+    {
+
+        std::cout << "p12-refactor HWP-p10_setup_ref_clock failed fapirc =0x" << static_cast<uint32_t>(fapirc) << std::endl;
+		/*TODO ipl_log(IPL_ERROR,
+			"Istep set_ref_clock failed on chip %s, rc=%d \n",
+			pdbg_target_path(proc), fapirc);*/
+		//rc++;
+	}
+    
+    std::cout << "p12-refactor istep0-set_ref_clock: done\n";
+    //TODO ipl_process_fapi_error(fapirc, proc);
+}
+catch(const std::exception& ex)
+{
+    std::cout << "exception during istep0-set_ref_clock exception: " << ex.what() << std::endl;
+}
+    return rc;
 }
 
 static int ipl_proc_clock_test(void)
 {
-	struct pdbg_target *proc;
 	int rc = 0;
-	fapi2::ReturnCode fapirc;
+try{
+    fapi2::ReturnCode fapirc;
 
 	if (ipl_type() == IPL_TYPE_MPIPL)
 		return -1;
 
-	ipl_log(IPL_INFO, "Istep: proc_clock_test: started\n");
+    std::cout << "p12-refactor istep0-proc_clock_test: started\n";
 
-	proc = ipl_get_functional_primary_proc();
-	if (proc == NULL) {
-		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
+	TARGETING::TargetPtr proc = getFunctionalMasterProc();
+
+    if (proc == nullptr)
+    {
+        std::cout << "p12-refactor istep0-proc_clock_test: proc is nullptr\n";
+		//ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
-	ipl_log(IPL_INFO,
+	/*TODO ipl_log(IPL_INFO,
 		"Running p10_clock_test HWP on primary processor %d\n",
-		pdbg_target_index(proc));
+		pdbg_target_index(proc));*/
+    std::cout << "p12-refactor: executing HWP-p10_clock_test\n";
 	fapirc = p10_clock_test(proc);
-	if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
-		ipl_log(IPL_ERROR, "HWP clock_test failed on proc %d, rc=%d\n",
-			pdbg_target_index(proc), fapirc);
-		rc++;
+    std::cout << "p12-refactor: executing HWP-p10_clock_test done\n";
+	if (fapirc != fapi2::FAPI2_RC_SUCCESS)
+    {
+        std::cout << "p12-refactor HWP-p10_clock_test failed fapirc =0x" << static_cast<uint32_t>(fapirc) << std::endl;
+		/*TODO ipl_log(IPL_ERROR, "HWP clock_test failed on proc %d, rc=%d\n",
+			pdbg_target_index(proc), fapirc);*/
+		//rc++;
 	}
 
-	ipl_process_fapi_error(fapirc, proc);
+	//TODO ipl_process_fapi_error(fapirc, proc);
 
+    std::cout << "p12-refactor istep0-proc_clock_test: done\n";
+}
+catch(const std::exception& ex)
+{
+    std::cout << "exception during istep0-proc_clock_test exception: " << ex.what() << std::endl;
+}
 	return rc;
 }
 
@@ -1083,35 +1215,54 @@ static int ipl_asset_protection(void)
 
 static int ipl_proc_select_boot_prom(void)
 {
-	struct pdbg_target *proc;
 	int rc = 1;
-
-	ipl_log(IPL_INFO, "Istep: proc_select_boot_prom: started\n");
-
+try
+{
+    std::cout << "p12-refactor istep0-proc_select_boot_prom: started\n";
 	// Check the availabilty of primary processor.
-	if (!ipl_check_functional_master()) {
+	if (getFunctionalMasterProc() == nullptr)
+    {
 		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
-	pdbg_for_each_class_target("proc", proc)
-	{
+    using namespace TARGETING;
+
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
+
+    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+
+    for (auto&& proc :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred))
+    {
+        if (!ipl_is_master_proc(proc) || !ipl_is_functional(proc))
+            continue;
+
 		fapi2::ReturnCode fapirc;
 
-		if (!ipl_is_master_proc(proc) || !ipl_is_functional(proc))
-			continue;
-
-		ipl_log(IPL_INFO,
+		/*TODO ipl_log(IPL_INFO,
 			"Running p10_select_boot_master HWP on processor %d\n",
-			pdbg_target_index(proc));
+			pdbg_target_index(proc));*/
+        std::cout << "p12-refactor executing HWP-p10_select_boot_master\n";
 		fapirc = p10_select_boot_master(proc);
-		if (fapirc == fapi2::FAPI2_RC_SUCCESS)
+
+        std::cout << "p12-refactor executing HWP-p10_select_boot_master done\n";
+
+        if (fapirc == fapi2::FAPI2_RC_SUCCESS)
 			rc = 0;
 
-		ipl_process_fapi_error(fapirc, proc);
+		//TODO ipl_process_fapi_error(fapirc, proc);
 		break;
 	}
-
+}
+catch(const std::exception& ex)
+{
+    std::cout << "exception during proc_select_boot_prom exception: " << ex.what() << std::endl;
+}
+    rc = 0;
+    std::cout << "p12-refactor istep0-proc_select_boot_prom: done\n";
 	return rc;
 }
 
@@ -1122,30 +1273,33 @@ static int ipl_hb_config_update(void)
 
 static int ipl_sbe_config_update(void)
 {
-	struct pdbg_target *root, *proc;
+	using namespace TARGETING;
 	int rc = 1;
-	uint8_t istep_mode, core_mode, disable_security, attr_override;
-	uint8_t scom_allowed;
-
-	fapi2::buffer<uint32_t> boot_flags;
-
-	ipl_log(IPL_INFO, "Istep: sbe_config_update: started\n");
+try
+{
+    std::cout << "p12-refactor istep0-sbe_config_update: started\n";
 
 	// Check the availabilty of primary processor.
-	if (!ipl_check_functional_master()) {
+	if (getFunctionalMasterProc() == nullptr)
+    {
 		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
-	root = pdbg_target_root();
-	if (!pdbg_target_get_attribute(root, "ATTR_ISTEP_MODE", 1, 1,
-				       &istep_mode)) {
-		ipl_log(IPL_ERROR,
-			"Attribute [ATTR_ISTEP_MODE] read failed \n");
-		return 1;
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
+
+    AttributeTraits<ATTR_ISTEP_MODE>::Type istep_mode;
+
+    if(!top->tryGetAttr<ATTR_ISTEP_MODE>(istep_mode))
+    {
+        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_ISTEP_MODE\n";
+		//return 1;
 	}
 
-	// Bit 0 indicates istep IPL (0b1) (Used by SBE, HB – ATTR_ISTEP_MODE)
+	fapi2::buffer<uint32_t> boot_flags;
+
+     // Bit 0 indicates istep IPL (0b1) (Used by SBE, HB – ATTR_ISTEP_MODE)
 	if (istep_mode)
 		boot_flags.setBit(0);
 	else
@@ -1154,11 +1308,12 @@ static int ipl_sbe_config_update(void)
 	// Set the Security Disable bit based on the ATTR_DISABLE_SECURITY
 	// attribute. Its "0" by default, i.e. security is always enabled by
 	// default, unless user overrides the value.
-	if (!pdbg_target_get_attribute(root, "ATTR_DISABLE_SECURITY", 1, 1,
-				       &disable_security)) {
-		ipl_log(IPL_ERROR,
-			"Attribute [ATTR_DISABLE_SECURITY] read failed \n");
-		return 1;
+    AttributeTraits<ATTR_DISABLE_SECURITY>::Type disable_security;
+
+    if(!top->tryGetAttr<ATTR_DISABLE_SECURITY>(disable_security))
+    {
+        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_DISABLE_SECURITY\n";
+		//return 1;
 	}
 
 	// Bit 4 and 5 Enable SBE FFDC collection.
@@ -1171,151 +1326,182 @@ static int ipl_sbe_config_update(void)
 	else
 		boot_flags.clearBit(6);
 
+
 	// bit 7 - Allow hostboot attribute overrides. 0b1 indicates enable
-	if (!pdbg_target_get_attribute(root, "ATTR_ALLOW_ATTR_OVERRIDES", 1, 1,
-				       &attr_override)) {
-		ipl_log(IPL_ERROR,
-			"Attribute [ATTR_ALLOW_ATTR_OVERRIDES] read failed \n");
-		return 1;
+    AttributeTraits<ATTR_ALLOW_ATTR_OVERRIDES>::Type attr_override;
+    if(!top->tryGetAttr<ATTR_ALLOW_ATTR_OVERRIDES>(attr_override))
+    {
+        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_ALLOW_ATTR_OVERRIDES\n";
+		//return 1;
 	}
+
 	if (attr_override)
 		boot_flags.setBit(7);
 	else
 		boot_flags.clearBit(7);
 
 	// bit 11 - Disable denial list based SCOM access. 0b1 indicates disable
-	if (!pdbg_target_get_attribute(root, "ATTR_NO_XSCOM_ENFORCEMENT", 1, 1,
-				       &scom_allowed)) {
-		ipl_log(IPL_ERROR,
-			"Attribute [ATTR_NO_XSCOM_ENFORCEMENT] read failed \n");
-		return 1;
+    AttributeTraits<ATTR_NO_XSCOM_ENFORCEMENT>::Type scom_allowed;
+    if(!top->tryGetAttr<ATTR_NO_XSCOM_ENFORCEMENT>(scom_allowed))
+    {
+        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_NO_XSCOM_ENFORCEMENT\n";
+		//return 1;
 	}
+
 	if (scom_allowed)
 		boot_flags.setBit(11);
 	else
 		boot_flags.clearBit(11);
 
-	if (!pdbg_target_set_attribute(root, "ATTR_BOOT_FLAGS", 4, 1,
-				       &boot_flags)) {
-		ipl_log(IPL_ERROR,
-			"Attribute [ATTR_BOOT_FLAGS] update failed \n");
-		return 1;
+    if(!top->trySetAttr<ATTR_BOOT_FLAGS>(boot_flags))
+    {
+        std::cout << "p12-refactor istep0-sbe_config_update: trysetattr failed ATTR_BOOT_FLAGS\n";
+		//return 1;
 	}
 
-	if (small_core_enabled())
-		core_mode = 0x00; /* CORE_UNFUSED mode */
-	else
-		core_mode = 0x01; /* CORE_FUSED mode */
 
-	if (!pdbg_target_set_attribute(root, "ATTR_FUSED_CORE_MODE", 1, 1,
-				       &core_mode)) {
-		ipl_log(IPL_ERROR,
-			"Attribute [ATTR_FUSED_CORE_MODE] update failed \n");
-		return 1;
-	}
+    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
 
-	pdbg_for_each_class_target("proc", proc)
-	{
+    for (auto&& proc :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred))
+    {
 		fapi2::ReturnCode fapirc;
 
 		// Run HWP only on functional master processor
 		if (!ipl_is_master_proc(proc) || !ipl_is_functional(proc))
 			continue;
 
-		ipl_log(IPL_INFO,
-			"Running p10_setup_sbe_config HWP on processor %d\n",
-			pdbg_target_index(proc));
-		fapirc = p10_setup_sbe_config(proc);
+        std::cout << "p12-refactor executing HWP-p10_setup_sbe_config\n";
+
+        fapirc = p10_setup_sbe_config(proc);
+
+        std::cout << "p12-refactor executing HWP-p10_setup_sbe_config done\n";
+
 		if (fapirc == fapi2::FAPI2_RC_SUCCESS)
 			rc = 0;
 
-		ipl_process_fapi_error(fapirc, proc);
+		//TODO ipl_process_fapi_error(fapirc, proc);
 		break;
 	}
-
+}
+catch(const std::exception& ex)
+{
+    std::cout << "exception during sbe_config_update exception: " << ex.what() << std::endl;
+}
+    
+    std::cout << "p12-refactor istep0-sbe_config_update: done\n";
+    rc = 0;
 	return rc;
 }
 
 static int ipl_sbe_start(void)
 {
-	struct pdbg_target *proc;
-	int rc = 1, ret = 0;
+	std::cout << "p12-refactor istep0-sbe_start: started\n";
+    using namespace TARGETING;
+    using namespace ipl;
 
-	ipl_log(IPL_INFO, "Istep: sbe_start: started\n");
+    int rc = 1, ret = 0;
+try{
+    auto& ts = TargetService::instance();
 
-	pdbg_for_each_class_target("proc", proc)
-	{
-		fapi2::ReturnCode fapirc;
+    PredicatePostfixExpr pred;
+    pred.push(std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC))
+        .push(std::make_shared<PredicateIsFunctional>())
+        .And();
 
-		if (!ipl_is_functional(proc))
-			continue;
+    auto top = ts.getTopLevelTarget();
 
-		if (ipl_mode() == IPL_CRONUS) {
-			ipl_log(IPL_INFO,
-				"Running p10_start_cbs HWP on processor %d\n",
-				pdbg_target_index(proc));
+    for (auto&& proc :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred))
+    {
+        fapi2::ReturnCode fapirc;
+
+        if (ipl_mode() == IPL_CRONUS)
+        {
 			fapirc = p10_start_cbs(proc, true);
+
 			if (fapirc != fapi2::FAPI2_RC_SUCCESS)
 				ret++;
 
-			ipl_process_fapi_error(fapirc, proc);
+			//TODO ipl_process_fapi_error(fapirc, proc);
 			rc = ret;
 			continue;
 		}
 
-		// Run HWP or MPIPL chip-op only on master processor in
+        // Run HWP or MPIPL chip-op only on master processor in
 		// non cronus mode
-		if (ipl_is_master_proc(proc)) {
-			if (ipl_type() == IPL_TYPE_MPIPL) {
-				ipl_error_type err =
-				    ipl_sbe_mpipl_continue(proc);
+        if(ipl_is_master_proc(proc))
+        {
+			if (ipl_type() == IPL_TYPE_MPIPL)
+            {
+				ipl_error_type err = ipl::sbe::ipl_sbe_mpipl_continue(proc);
 				ipl_error_callback(err);
 				rc = err;
-			} else {
-				ipl_error_type err_type = IPL_ERR_OK;
+			}
+            else
+            {
+				//ipl_error_type err_type = IPL_ERR_OK;
 
+                std::cout << "p12-refactor executing HWP-start_cbs\n";
 				fapirc = p10_start_cbs(proc, true);
-				if (fapirc == fapi2::FAPI2_RC_SUCCESS) {
+
+                std::cout << "p12-refactor done HWP-start_cbs\n";
+                if (fapirc == fapi2::FAPI2_RC_SUCCESS)
+                {
 					// Update Primary processor SBE state to
 					// check cfam. Boot error callback is
 					// only required for failure.
-					ipl_set_sbe_state(proc,
-							  SBE_STATE_CHECK_CFAM);
+                    using namespace ipl::sbe;
+					ipl_sbe_set_state(proc, ipl::sbe::SBE_STATE_CHECK_CFAM);
 
-					if (!ipl_sbe_booted(proc, 25)) {
-						ipl_log(IPL_ERROR,
-							"SBE did not boot\n");
-						err_type = IPL_ERR_SBE_BOOT;
-					} else {
+                    if (!ipl_sbe_booted(proc, 25))
+                    {
+                        std::cout << "p12-refactor istep0-sbe_start: sbe did not boot\n";
+						//err_type = IPL_ERR_SBE_BOOT;
+					}
+                    else
+                    {
 						// Update Primary processor SBE
 						// state to booted Boot error
 						// callback is only required for
 						// failure.
-						ipl_set_sbe_state(
-						    proc, SBE_STATE_BOOTED);
+						ipl_sbe_set_state(proc, ipl::sbe::SBE_STATE_BOOTED);
 						rc = 0;
 					}
-				} else {
-					err_type = IPL_ERR_HWP;
 				}
-				ipl_error_callback(err_type);
+                else
+                {
+					//err_type = IPL_ERR_HWP;
+				}
+				//ipl_error_callback(err_type);
 				break;
 			}
 		}
 	}
 
-	if (!rc) {
+	if (!rc)
+    {
 		// Update Secondary processors SBE state to check cfam
 		// Boot error callback is required for failue
-		ipl_set_sbe_state_all_sec(SBE_STATE_CHECK_CFAM);
+        using namespace ipl::sbe;
+		ipl_set_sbe_state_all(ipl::sbe::SBE_STATE_CHECK_CFAM, true);
 
-		if (!ipl_check_functional_master()) {
+		if (getFunctionalMasterProc() == nullptr)
+        {
 			ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 			return 1;
 		}
-	}
-
-	return rc;
+    }
+}
+catch(const std::exception& ex)
+{
+    std::cout << "exception during sbe_start exception: " << ex.what() << std::endl;
+}
+    
+    std::cout << "p12-refactor istep0-sbe_start: done\n";
+    return rc;
 }
 
 static int ipl_startPRD(void)
@@ -1325,40 +1511,55 @@ static int ipl_startPRD(void)
 
 static int ipl_proc_attn_listen(void)
 {
-	struct pdbg_target *fsi, *proc = NULL;
+    using namespace TARGETING;
+
+    auto& ts = TargetService::instance();
+    auto top = ts.getTopLevelTarget();
+    
+    auto typeProc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC);
+    auto masterProc = std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0);
+    PredicatePostfixExpr masterFuncProcPred;
+    masterFuncProcPred.push(typeProc).push(masterProc).And();
+   
+    auto isMc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_MC);
+    auto isCore = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_CORE);
+    auto isPauc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAUC);
+    auto isPau = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAU);
+    auto isIohs = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_IOHS);
+    auto isPec = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PEC);
+    auto isFc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_FC);
+
+    PredicatePostfixExpr expr;
+    expr.push(isMc).push(isCore).Or()
+        .push(isPauc).push(isPau).Or()
+        .push(isIohs).push(isPec).Or()
+        .push(isFc).Or();
+
+    auto proc_target = ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &masterFuncProcPred);
+ 
+    if(proc_target.empty() || (proc_target.size() != 1))
+    {
+        std::cerr << "p12-refactor istep0-ipl_proc_attn_listen: invalid master proc count\n";
+        return 1;
+    }
+   
+	/*TODO ipl_log(IPL_INFO, "enable attention listen on processor %d\n",
+		pdbg_target_index(proc));*/
+    
+
 	uint32_t regval; // for register read/write
-	char path[16];
-	int rc;
 
-	pdbg_for_each_class_target("proc", proc)
-	{
-		if (!ipl_is_functional(proc))
-			continue;
-
-		if (ipl_is_master_proc(proc))
-			break;
-	}
-
-	if (!proc) {
-		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
-		return 1;
-	}
-
-	sprintf(path, "/proc%d/fsi", pdbg_target_index(proc));
-	fsi = pdbg_target_from_path(NULL, path);
-	if (!fsi) {
-		ipl_error_callback(IPL_ERR_FSI_TGT_NOT_FOUND);
-		return 1;
-	}
-
-	ipl_log(IPL_INFO, "enable attention listen on processor %d\n",
-		pdbg_target_index(proc));
-
-	rc = fsi_read(fsi, 0x100d, &regval); // FSI2_PIB_TRUE_MASK
-	if (rc != 0) {
+    // FSI2_PIB_TRUE_MASK
+    int rc = hwaccess::HwAccessIntf::getCfamRegister(proc_target.front(), 0x100d, regval); 
+	
+    if (rc != 0)
+    {
 		ipl_log(IPL_ERROR, "read TRUEMASK register failed, rc=%d\n",
 			rc);
-	} else {
+	}
+    else 
+    {
 		// ANY_ERROR, RECOVERABLE_ERROR
 		regval &= ~0x90000000; // mask
 
@@ -1366,15 +1567,18 @@ static int ipl_proc_attn_listen(void)
 		// SELFBOOT_ENGINE_ATTENTION
 		regval |= 0x60000002; // un-mask
 
-		rc = fsi_write(fsi, 0x100d, regval); // FSI2_PIB_TRUE_MASK
-		if (rc != 0) {
+        // FSI2_PIB_TRUE_MASK
+        rc = hwaccess::HwAccessIntf::putCfamRegister(proc_target.front(), 0x100d, regval); 
+
+        if (rc != 0) 
+        {
 			ipl_log(IPL_ERROR,
 				"write TRUEMASK register failed, rc=%d\n", rc);
 		}
 	}
 
 	ipl_error_callback((rc == 0) ? IPL_ERR_OK : IPL_ERR_FSI_REG);
-	return rc;
+	return rc;	
 }
 
 static struct ipl_step ipl0[] = {

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -144,7 +144,7 @@ static bool set_or_clear_state(TARGETING::TargetPtr target, bool do_set)
     AttributeTraits<ATTR_HWAS_STATE>::Type hwas;
     if(!target->tryGetAttr<ATTR_HWAS_STATE>(hwas))
     {
-        std::cerr << "p12-refactor set_or_clear_state Attribute read failed\n";
+        std::cerr << "phal-refactor set_or_clear_state Attribute read failed\n";
 		return false;
     }
     
@@ -158,7 +158,7 @@ static bool set_or_clear_state(TARGETING::TargetPtr target, bool do_set)
 
     if(!target->trySetAttr<ATTR_HWAS_STATE>(hwas))
     {
-        std::cerr << "p12-refactor set_or_clear_state Attribute write failed\n";
+        std::cerr << "phal-refactor set_or_clear_state Attribute write failed\n";
 		return false;
     }
 
@@ -190,7 +190,7 @@ static bool update_clock_func_state(void)
 
     if(!top->tryGetAttr<ATTR_SYS_CLOCK_DECONFIG_STATE>(clk_state))
     {
-        std::cout << "p12-refactor trygetattr failed ATTR_SYS_CLOCK_DECONFIG_STATE\n";
+        std::cout << "phal-refactor trygetattr failed ATTR_SYS_CLOCK_DECONFIG_STATE\n";
         ipl_log(
 		    IPL_ERROR,
 		    "Attribute [ATTR_SYS_CLOCK_DECONFIG_STATE] read failed \n");
@@ -219,7 +219,7 @@ static bool update_clock_func_state(void)
 				pdbg_target_path(clock_target));*/
 			if (!set_or_clear_state(clock_target, false))
             {
-                std::cout << "p12-refactor setorclearstate-1 failed\n";
+                std::cout << "phal-refactor setorclearstate-1 failed\n";
 				//return false;
 			}
 			continue;
@@ -230,7 +230,7 @@ static bool update_clock_func_state(void)
 
         if(!clock_target->tryGetAttr<ATTR_POSITION>(clk_pos))
         {
-            std::cout << "p12-refactor trygetattr failed ATTR_POSITION\n";
+            std::cout << "phal-refactor trygetattr failed ATTR_POSITION\n";
             /*TODO ipl_log(IPL_ERROR, "Attribute ATTR_POSITION read failed"
                     " for clock '%s' \n", pdbg_target_path(clock_target));*/
 
@@ -256,7 +256,7 @@ static bool update_clock_func_state(void)
 
 			if (!set_or_clear_state(clock_target, false))
             {
-                std::cout << "p12-refactor setorclearstate-2 failed\n";
+                std::cout << "phal-refactor setorclearstate-2 failed\n";
 				//TODO return false;
 			}
 		}
@@ -543,6 +543,7 @@ static bool update_clock_func_state(void)
  */
 static void apply_fco_override(void)
 {
+    std::cout << "phal-refactor Executing apply_fco_override\n" ;
     using namespace TARGETING;
     auto& ts = TargetService::instance();
     auto top = ts.getTopLevelTarget();
@@ -559,19 +560,23 @@ static void apply_fco_override(void)
     auto isIohs = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_IOHS);
     auto isPec = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PEC);
     auto isFc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_FC);
+    auto isPerv = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PERV);
 
     PredicatePostfixExpr expr;
     expr.push(isMc).push(isCore).Or()
-        .push(isPauc).push(isPau).Or()
-        .push(isIohs).push(isPec).Or()
-        .push(isFc).Or();
+        .push(isPauc).Or()
+        .push(isPau).Or()
+        .push(isIohs).Or()
+        .push(isPec).Or()
+        .push(isFc).Or()
+        .push(isPerv).Or();
 
     auto proc_targets = ts.getAssociated(top, AssociationType::childByPhysical,
                              RecursionLevel::all, &masterFuncProcPred);
  
     if(proc_targets.empty() || (proc_targets.size() != 1))
     {
-        std::cerr << "p12-refactor apply_fco_override: invalid master proc count\n";
+        std::cerr << "phal-refactor apply_fco_override: invalid master proc count\n";
         return;
     }
 
@@ -583,14 +588,16 @@ static void apply_fco_override(void)
 
         if(hwas.functionalOverride)
         {
+            std::cout << "phal-refactor applying functional override\n" ;
             hwas.present = 1;
             hwas.functional = 1;
             if(!pchild->trySetAttr<ATTR_HWAS_STATE>(hwas))
             {
-               std::cerr << "p12-refactor apply_fco_override Attribute write failed\n";
+               std::cerr << "phal-refactor apply_fco_override Attribute write failed\n";
             }
         }
     }
+    std::cout << "phal-refactor Done apply_fco_override\n" ;
 }
 
 //@Brief Function will set the functional and present state of master proc
@@ -600,145 +607,12 @@ static void apply_fco_override(void)
 // It will also update functional state oscrefclk target.
 static bool update_genesis_hwas_state(void)
 {
-    /* TODO p12-refactor
-	std::array<const char *, 8> mProcChild = {
-	    "core", "pauc", "pau", "iohs", "mc", "chiplet", "pec", "fc"};
-	struct pdbg_target *proc, *child, *clock_target;
-
-	bool target_enabled = false;
-	enum pdbg_target_status status;
-	uint8_t clk_pos = 0;
-	std::vector<std::pair<std::string, std::string>> ffdcs;
-
-	pdbg_for_each_class_target("proc", proc)
-	{
-		if (pdbg_target_status(proc) != PDBG_TARGET_ENABLED) {
-			target_enabled = false;
-		} else {
-			target_enabled = true;
-		}
-
-		if (!set_or_clear_state(proc, target_enabled)) {
-			ipl_log(IPL_ERROR,
-				"Failed to set HWAS state of proc %d\n",
-				pdbg_target_index(proc));
-			ipl_error_callback(IPL_ERR_ATTR_WRITE);
-			return false;
-		}
-
-		if (!ipl_is_master_proc(proc))
-			continue;
-
-		for (const char *data : mProcChild) {
-			pdbg_for_each_target(data, proc, child)
-			{
-				// mark targets as non functional in the devtree
-				// if it is marked UNUSED in the MRW. This is a workaround for
-				// handling unused IOHS targets in Bonnell.	
-				if (strcmp(data , "iohs") == 0)
-				{
-					ATTR_IOHS_CONFIG_MODE_Type iohs_config;
-					if (!pdbg_target_get_attribute(child,
-						"ATTR_IOHS_CONFIG_MODE",
-						1,
-						1, &iohs_config)) {
-						ipl_log(IPL_ERROR,
-							"Attribute ATTR_IOHS_CONFIG_MODE read failed"
-							" for iohs '%s' \n",
-							pdbg_target_path(child));
-						ipl_plat_procedure_error_handler(
-							IPL_ERR_ATTR_READ_FAIL);
-						return false;
-					}
-					if (iohs_config == ENUM_ATTR_IOHS_CONFIG_MODE_UNUSED) {
-						ipl_log(IPL_INFO,
-							"iohs(%s) setting to non functional \n",
-						pdbg_target_path(child));
-						if (!set_or_clear_state(child, false)) {
-							ipl_log(IPL_ERROR,
-								"Failed to set HWAS state of "
-								"%s, index %d\n",
-								data, pdbg_target_index(child));
-							ipl_error_callback(IPL_ERR_ATTR_WRITE);
-							return false;
-						}
-					}
-					else
-					{
-						if (!set_or_clear_state(child,
-							target_enabled)) {
-							ipl_log(IPL_ERROR,
-								"Failed to set HWAS state of "
-								"%s, index %d\n",
-								data, pdbg_target_index(child));
-							ipl_error_callback(IPL_ERR_ATTR_WRITE);
-							return false;
-						}
-					}
-				} //iohs
-				else {
-					if (!set_or_clear_state(child,
-							target_enabled)) {
-						ipl_log(IPL_ERROR,
-							"Failed to set HWAS state of "
-							"%s, index %d\n",
-							data, pdbg_target_index(child));
-						ipl_error_callback(IPL_ERR_ATTR_WRITE);
-						return false;
-					}
-				}
-			} //foreach
-		} //endfor
-	}
-
-	pdbg_for_each_class_target("oscrefclk", clock_target)
-	{
-		if (!pdbg_target_get_attribute(clock_target, "ATTR_POSITION", 2,
-					       1, &clk_pos)) {
-
-			ipl_log(IPL_ERROR,
-				"Attribute ATTR_POSITION read failed"
-				" for clock '%s' \n",
-				pdbg_target_path(clock_target));
-			ipl_plat_procedure_error_handler(
-			    IPL_ERR_ATTR_READ_FAIL);
-			// IPL need to be failed if this step is failed for any
-			// clock, since this clock cannot be marked as
-			// functional
-			return false;
-		}
-
-		status = pdbg_target_probe(clock_target);
-		if (status != PDBG_TARGET_ENABLED) {
-			ipl_log(
-			    IPL_ERROR,
-			    "clock '%s' is not operational, pdbg status = %d\n",
-			    pdbg_target_path(clock_target), status);
-
-			ffdcs.push_back(std::make_pair("PDBG_STATUS",
-						       std::to_string(status)));
-			ffdcs.push_back(std::make_pair("FAIL_TYPE",
-						       "CHIP_NOT_OPERATIONAL"));
-			ipl_plat_clock_error_handler(ffdcs, clk_pos);
-			// IPL need to be failed if any clock is not operational
-			return false;
-		}
-		if (!set_or_clear_state(clock_target, true)) {
-			ipl_log(IPL_ERROR,
-				"Failed to set HWAS state of oscrefclk, %s\n",
-				pdbg_target_path(clock_target));
-			return false;
-		}
-	}
-
-	return true;*/
-
-    #if 0 //TODO p12-refactor
     using namespace TARGETING;
     auto& ts = TargetService::instance();
     auto top = ts.getTopLevelTarget();
 
-    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+    PredicatePostfixExpr procExpr;
+    procExpr.push(std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC));
 
     auto isMc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_MC);
     auto isCore = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_CORE);
@@ -747,41 +621,57 @@ static bool update_genesis_hwas_state(void)
     auto isIohs = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_IOHS);
     auto isPec = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PEC);
     auto isFc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_FC);
-
+    auto isPerv = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PERV);
+    
     PredicatePostfixExpr expr;
-    expr.push(isMc).push(isCore).push(isPauc).push(isPau)
-        .push(isIohs).push(isPec).push(isFc).Or();
+    expr.push(isMc).push(isCore).Or()
+        .push(isPauc).Or()
+        .push(isPau).Or()
+        .push(isIohs).Or()
+        .push(isPec).Or()
+        .push(isFc).Or()
+        .push(isPerv).Or();
 
     for (auto&& proc :
             ts.getAssociated(top, AssociationType::childByPhysical,
-                             RecursionLevel::all, &pred))
+                             RecursionLevel::all, &procExpr))
     {
 		if (!set_or_clear_state(proc, true))
         {
-            std::cout << "DEMO: failed to set proc hwas state\n";
+            std::cout << "phal-refactor failed to set proc hwas state\n";
 			/*TODO ipl_log(IPL_ERROR,
 				"Failed to set HWAS state of proc %d\n",
 				pdbg_target_index(proc));
 			ipl_error_callback(IPL_ERR_ATTR_WRITE);*/
 			return false;
 		}
+    }
 
-        if(!ipl_is_master_proc(proc))
-                continue;
+    //the master proc
+    procExpr.push(std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0))
+            .And();
 
-        for (auto&& pchild :
-                ts.getAssociated(top, AssociationType::childByPhysical,
-                                 RecursionLevel::all, &expr))
+    auto master_proc = ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &procExpr);
+    
+    if(master_proc.empty() || (master_proc.size() != 1))
+    {
+        std::cerr << "phal-refactor update_genesis_hwas_state: invalid master proc count\n";
+        return 1;
+    }
+
+    for (auto&& pchild :
+            ts.getAssociated(master_proc.front(), AssociationType::childByPhysical,
+                             RecursionLevel::all, &expr))
+    {
+        if (!set_or_clear_state(pchild,true))
         {
-            if (!set_or_clear_state(pchild,true))
-            {
-                /*TODO ipl_log(IPL_ERROR,
-                    "Failed to set HWAS state of "
-                    "%s, index %d\n",
-                    data, pdbg_target_index(child));
-                ipl_error_callback(IPL_ERR_ATTR_WRITE);*/
-                return false;
-			}
+            /*TODO ipl_log(IPL_ERROR,
+                "Failed to set HWAS state of "
+                "%s, index %d\n",
+                data, pdbg_target_index(child));
+            ipl_error_callback(IPL_ERR_ATTR_WRITE);*/
+            return false;
         }
     }
 
@@ -797,7 +687,7 @@ static bool update_genesis_hwas_state(void)
         if(!clock_target->tryGetAttr<ATTR_POSITION>(clk_pos))
         {
 
-            std::cout << "DEMO trygetattr failed to get clock's ATTR_POSITION\n";
+            std::cout << "phal-refactor trygetattr failed to get clock's ATTR_POSITION\n";
             /*TODO ipl_log(IPL_ERROR, "Attribute ATTR_POSITION read failed"
                     " for clock '%s' \n", pdbg_target_path(clock_target));*/
 
@@ -808,11 +698,10 @@ static bool update_genesis_hwas_state(void)
 
         if (!set_or_clear_state(clock_target, true))
         {
-            std::cout << "DEMO failed to set clock as functional \n";
+            std::cout << "phal-refactor failed to set clock as functional \n";
             return false;
         }
     }
-#endif
     return true;
 }
 
@@ -823,7 +712,7 @@ static int ipl_updatehwmodel(void)
 	constexpr auto GENESIS_BOOT_FILE = "/var/lib/phal/genesisboot";
 	fs::path genesis_boot_file = GENESIS_BOOT_FILE;
 
-    std::cout << "p12-refactor istep0-updatehwmodel: started\n";
+    std::cout << "phal-refactor istep0.4 ( updatehwmodel ): started\n";
 
 	if (!fs::exists(genesis_boot_file)) {
 		ipl_log(IPL_INFO, "updatehwmodel: Genesis mode boot\n");
@@ -863,18 +752,18 @@ static int ipl_updatehwmodel(void)
 		// SYS_CLOCK_DECONFIG_STATE values.
 		if (!update_clock_func_state())
         {
-            std::cout << "p12-refactor ipl0-updatehwmodel: updateclockfuncstate failed\n";
+            std::cout << "phal-refactor ipl0.4 ( updatehwmodel ): updateclockfuncstate failed\n";
 		}
 	}
 
 	if (getFunctionalMasterProc() == nullptr)
     {
-        std::cout << "p12-refactor istep0-updatehwmodel: no functional master\n";
+        std::cout << "phal-refactor istep0.4 ( updatehwmodel ): no functional master\n";
 		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
-    std::cout << "p12-refactor istep0-updatehwmodel: done\n";
+    std::cout << "phal-refactor istep0.4 ( updatehwmodel ): done\n";
 	return 0;
 }
 
@@ -1092,18 +981,18 @@ try{
 	if (ipl_type() == IPL_TYPE_MPIPL)
 		return -1;
 
-    std::cout << "p12-refactor istep0-set_ref_clock: started\n";
+    std::cout << "phal-refactor istep0.6 ( set_ref_clock ): started\n";
 
     TargetPtr proc = getFunctionalMasterProc();
 
 	if (proc == nullptr)
     {
-        std::cout << "p12-refactor istep0-set_ref_clock: proc is nullptr\n";
+        std::cout << "phal-refactor istep0.6 ( set_ref_clock ): proc is nullptr\n";
 		//ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
 
-/*TODO p12-refactor
+/*TODO phal-refactor
 	if (initialize_and_check_clock_chip(clock_select)) {
 		ipl_log(IPL_ERROR, "Clock initialization failed\n");
 		return 1;
@@ -1116,39 +1005,39 @@ try{
 
     if(!proc->trySetAttr<ATTR_CP_REFCLOCK_SELECT>(clock_select))
     {
-        std::cout << "p12-refactor istep0- set_ref_clock: trysetattr failed ATTR_CP_REFCLOCK_SELECT\n";
+        std::cout << "phal-refactor istep0.6 ( set_ref_clock ): trysetattr failed ATTR_CP_REFCLOCK_SELECT\n";
 		/*TODO ipl_log(IPL_ERROR,
 			"Attribute CP_REFCLOCK_SELECT update failed"
 			" for proc %d \n",
 			pdbg_target_index(proc));*/
 		//ipl_plat_procedure_error_handler(IPL_ERR_ATTR_WRITE);
-		//rc++;
-		//return 1;
+		rc++;
+		return 1;
     }
 
 	/*TODO ipl_log(IPL_INFO,
 		"Running p10_setup_ref_clock HWP on primary processor %d\n",
 		pdbg_target_index(proc));*/
-    std::cout << "p12-refactor: executing HWP-p10_setup_ref_clock\n";
+    std::cout << "phal-refactor Executing HWP( p10_setup_ref_clock )\n";
 	fapirc = p10_setup_ref_clock(proc);
-    std::cout << "p12-refactor: executing HWP-p10_setup_ref_clock done\n";
+    std::cout << "phal-refactor Done HWP( p10_setup_ref_clock ) \n";
 
     if (fapirc != fapi2::FAPI2_RC_SUCCESS)
     {
 
-        std::cout << "p12-refactor HWP-p10_setup_ref_clock failed fapirc =0x" << static_cast<uint32_t>(fapirc) << std::endl;
+        std::cout << "phal-refactor HWP( p10_setup_ref_clock ) failed fapirc =0x" << static_cast<uint32_t>(fapirc) << std::endl;
 		/*TODO ipl_log(IPL_ERROR,
 			"Istep set_ref_clock failed on chip %s, rc=%d \n",
 			pdbg_target_path(proc), fapirc);*/
-		//rc++;
+		rc++;
 	}
     
-    std::cout << "p12-refactor istep0-set_ref_clock: done\n";
+    std::cout << "phal-refactor istep0.6 ( set_ref_clock ): done\n";
     //TODO ipl_process_fapi_error(fapirc, proc);
 }
 catch(const std::exception& ex)
 {
-    std::cout << "exception during istep0-set_ref_clock exception: " << ex.what() << std::endl;
+    std::cout << "exception during istep0.6 (set_ref_clock) exception: " << ex.what() << std::endl;
 }
     return rc;
 }
@@ -1162,13 +1051,13 @@ try{
 	if (ipl_type() == IPL_TYPE_MPIPL)
 		return -1;
 
-    std::cout << "p12-refactor istep0-proc_clock_test: started\n";
+    std::cout << "phal-refactor istep0.7 ( proc_clock_test ): started\n";
 
 	TARGETING::TargetPtr proc = getFunctionalMasterProc();
 
     if (proc == nullptr)
     {
-        std::cout << "p12-refactor istep0-proc_clock_test: proc is nullptr\n";
+        std::cout << "phal-refactor istep0.7 ( proc_clock_test ): proc is nullptr\n";
 		//ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
 	}
@@ -1176,24 +1065,24 @@ try{
 	/*TODO ipl_log(IPL_INFO,
 		"Running p10_clock_test HWP on primary processor %d\n",
 		pdbg_target_index(proc));*/
-    std::cout << "p12-refactor: executing HWP-p10_clock_test\n";
+    std::cout << "phal-refactor Executing HWP( p10_clock_test )\n";
 	fapirc = p10_clock_test(proc);
-    std::cout << "p12-refactor: executing HWP-p10_clock_test done\n";
+    std::cout << "phal-refactor Done HWP( p10_clock_test ) \n";
 	if (fapirc != fapi2::FAPI2_RC_SUCCESS)
     {
-        std::cout << "p12-refactor HWP-p10_clock_test failed fapirc =0x" << static_cast<uint32_t>(fapirc) << std::endl;
+        std::cout << "phal-refactor HWP( p10_clock_test ) failed fapirc =0x" << static_cast<uint32_t>(fapirc) << std::endl;
 		/*TODO ipl_log(IPL_ERROR, "HWP clock_test failed on proc %d, rc=%d\n",
 			pdbg_target_index(proc), fapirc);*/
-		//rc++;
+		rc++;
 	}
 
 	//TODO ipl_process_fapi_error(fapirc, proc);
 
-    std::cout << "p12-refactor istep0-proc_clock_test: done\n";
+    std::cout << "phal-refactor istep0.7 ( proc_clock_test ): done\n";
 }
 catch(const std::exception& ex)
 {
-    std::cout << "exception during istep0-proc_clock_test exception: " << ex.what() << std::endl;
+    std::cout << "exception during istep0.7 ( proc_clock_test ) exception: " << ex.what() << std::endl;
 }
 	return rc;
 }
@@ -1218,7 +1107,7 @@ static int ipl_proc_select_boot_prom(void)
 	int rc = 1;
 try
 {
-    std::cout << "p12-refactor istep0-proc_select_boot_prom: started\n";
+    std::cout << "phal-refactor istep0.11 ( proc_select_boot_prom ): started\n";
 	// Check the availabilty of primary processor.
 	if (getFunctionalMasterProc() == nullptr)
     {
@@ -1231,38 +1120,45 @@ try
     auto& ts = TargetService::instance();
     auto top = ts.getTopLevelTarget();
 
-    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
-
-    for (auto&& proc :
-            ts.getAssociated(top, AssociationType::childByPhysical,
-                             RecursionLevel::all, &pred))
+    auto typeProc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC);
+    auto masterProc = std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0);
+    auto isFunctional = std::make_shared<PredicateIsFunctional>();
+    
+    PredicatePostfixExpr pred;
+    pred.push(typeProc).push(masterProc).And()
+        .push(isFunctional).And();
+        
+    auto proc_target = ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred);
+ 
+    if(proc_target.empty() || (proc_target.size() != 1))
     {
-        if (!ipl_is_master_proc(proc) || !ipl_is_functional(proc))
-            continue;
+        std::cerr << "phal-refactor istep0.11 (proc_select_boot_prom): invalid master proc count\n";
+        return 1;
+    }
+    
+    fapi2::ReturnCode fapirc;
 
-		fapi2::ReturnCode fapirc;
+    /*TODO ipl_log(IPL_INFO,
+        "Running p10_select_boot_master HWP on processor %d\n",
+        pdbg_target_index(proc));*/
+    std::cout << "phal-refactor Executing HWP( p10_select_boot_master )\n";
 
-		/*TODO ipl_log(IPL_INFO,
-			"Running p10_select_boot_master HWP on processor %d\n",
-			pdbg_target_index(proc));*/
-        std::cout << "p12-refactor executing HWP-p10_select_boot_master\n";
-		fapirc = p10_select_boot_master(proc);
+    fapirc = p10_select_boot_master(proc_target.front());
 
-        std::cout << "p12-refactor executing HWP-p10_select_boot_master done\n";
+    std::cout << "phal-refactor Done HWP( p10_select_boot_master ) \n";
 
-        if (fapirc == fapi2::FAPI2_RC_SUCCESS)
-			rc = 0;
+    if (fapirc == fapi2::FAPI2_RC_SUCCESS)
+        rc = 0;
 
-		//TODO ipl_process_fapi_error(fapirc, proc);
-		break;
-	}
+    //TODO ipl_process_fapi_error(fapirc, proc);
 }
 catch(const std::exception& ex)
 {
     std::cout << "exception during proc_select_boot_prom exception: " << ex.what() << std::endl;
 }
     rc = 0;
-    std::cout << "p12-refactor istep0-proc_select_boot_prom: done\n";
+    std::cout << "phal-refactor istep0.11 ( proc_select_boot_prom ): done\n";
 	return rc;
 }
 
@@ -1277,7 +1173,7 @@ static int ipl_sbe_config_update(void)
 	int rc = 1;
 try
 {
-    std::cout << "p12-refactor istep0-sbe_config_update: started\n";
+    std::cout << "phal-refactor istep0.13 ( sbe_config_update ): started\n";
 
 	// Check the availabilty of primary processor.
 	if (getFunctionalMasterProc() == nullptr)
@@ -1293,8 +1189,8 @@ try
 
     if(!top->tryGetAttr<ATTR_ISTEP_MODE>(istep_mode))
     {
-        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_ISTEP_MODE\n";
-		//return 1;
+        std::cout << "phal-refactor istep0.13 ( sbe_config_update ): trygetattr failed ATTR_ISTEP_MODE\n";
+		return 1;
 	}
 
 	fapi2::buffer<uint32_t> boot_flags;
@@ -1312,8 +1208,8 @@ try
 
     if(!top->tryGetAttr<ATTR_DISABLE_SECURITY>(disable_security))
     {
-        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_DISABLE_SECURITY\n";
-		//return 1;
+        std::cout << "phal-refactor istep0.13 ( sbe_config_update ): trygetattr failed ATTR_DISABLE_SECURITY\n";
+		return 1;
 	}
 
 	// Bit 4 and 5 Enable SBE FFDC collection.
@@ -1331,8 +1227,8 @@ try
     AttributeTraits<ATTR_ALLOW_ATTR_OVERRIDES>::Type attr_override;
     if(!top->tryGetAttr<ATTR_ALLOW_ATTR_OVERRIDES>(attr_override))
     {
-        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_ALLOW_ATTR_OVERRIDES\n";
-		//return 1;
+        std::cout << "phal-refactor istep0.13 ( sbe_config_update ): trygetattr failed ATTR_ALLOW_ATTR_OVERRIDES\n";
+		return 1;
 	}
 
 	if (attr_override)
@@ -1344,8 +1240,8 @@ try
     AttributeTraits<ATTR_NO_XSCOM_ENFORCEMENT>::Type scom_allowed;
     if(!top->tryGetAttr<ATTR_NO_XSCOM_ENFORCEMENT>(scom_allowed))
     {
-        std::cout << "p12-refactor istep0-sbe_config_update: trygetattr failed ATTR_NO_XSCOM_ENFORCEMENT\n";
-		//return 1;
+        std::cout << "phal-refactor istep0.13 ( sbe_config_update ): trygetattr failed ATTR_NO_XSCOM_ENFORCEMENT\n";
+		return 1;
 	}
 
 	if (scom_allowed)
@@ -1355,12 +1251,19 @@ try
 
     if(!top->trySetAttr<ATTR_BOOT_FLAGS>(boot_flags))
     {
-        std::cout << "p12-refactor istep0-sbe_config_update: trysetattr failed ATTR_BOOT_FLAGS\n";
-		//return 1;
+        std::cout << "phal-refactor istep0.13 ( sbe_config_update ): trysetattr failed ATTR_BOOT_FLAGS\n";
+		return 1;
 	}
 
+    auto isFunctional = std::make_shared<PredicateIsFunctional>();
+    auto typeProc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC);
+    auto masterProc = 
+            std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0); 
+    // 0 = master proc
 
-    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+    PredicatePostfixExpr pred;
+    pred.push(typeProc).push(masterProc).And()
+        .push(isFunctional).And();
 
     for (auto&& proc :
             ts.getAssociated(top, AssociationType::childByPhysical,
@@ -1368,15 +1271,11 @@ try
     {
 		fapi2::ReturnCode fapirc;
 
-		// Run HWP only on functional master processor
-		if (!ipl_is_master_proc(proc) || !ipl_is_functional(proc))
-			continue;
-
-        std::cout << "p12-refactor executing HWP-p10_setup_sbe_config\n";
+        std::cout << "phal-refactor Executing HWP( p10_setup_sbe_config )\n";
 
         fapirc = p10_setup_sbe_config(proc);
 
-        std::cout << "p12-refactor executing HWP-p10_setup_sbe_config done\n";
+        std::cout << "phal-refactor Done  HWP( p10_setup_sbe_config )\n";
 
 		if (fapirc == fapi2::FAPI2_RC_SUCCESS)
 			rc = 0;
@@ -1390,18 +1289,19 @@ catch(const std::exception& ex)
     std::cout << "exception during sbe_config_update exception: " << ex.what() << std::endl;
 }
     
-    std::cout << "p12-refactor istep0-sbe_config_update: done\n";
+    std::cout << "phal-refactor istep0.13 ( sbe_config_update ): done\n";
     rc = 0;
 	return rc;
 }
 
 static int ipl_sbe_start(void)
 {
-	std::cout << "p12-refactor istep0-sbe_start: started\n";
+	std::cout << "phal-refactor istep0.14 ( sbe_start ): started\n";
     using namespace TARGETING;
     using namespace ipl;
 
     int rc = 1, ret = 0;
+    fapi2::ReturnCode fapirc; 
 try{
     auto& ts = TargetService::instance();
 
@@ -1416,8 +1316,6 @@ try{
             ts.getAssociated(top, AssociationType::childByPhysical,
                              RecursionLevel::all, &pred))
     {
-        fapi2::ReturnCode fapirc;
-
         if (ipl_mode() == IPL_CRONUS)
         {
 			fapirc = p10_start_cbs(proc, true);
@@ -1429,57 +1327,65 @@ try{
 			rc = ret;
 			continue;
 		}
+    }
+    
+    auto masterProc = std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0);
+    pred.push(masterProc).And();
+   
+    auto proc_target = ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred);
+ 
+    if(proc_target.empty() || (proc_target.size() != 1))
+    {
+        std::cerr << "phal-refactor istep0.14 ( sbe_start ): invalid master proc count\n";
+        return 1;
+    }
 
-        // Run HWP or MPIPL chip-op only on master processor in
-		// non cronus mode
-        if(ipl_is_master_proc(proc))
+    // Run HWP or MPIPL chip-op only on master processor in
+	// non cronus mode
+    if (ipl_type() == IPL_TYPE_MPIPL)
+    {
+        ipl_error_type err = ipl::sbe::ipl_sbe_mpipl_continue(proc_target.front());
+        ipl_error_callback(err);
+        rc = err;
+    }
+    else
+    {
+        //ipl_error_type err_type = IPL_ERR_OK;
+
+        std::cout << "phal-refactor Executing HWP( start_cbs )\n";
+        fapirc = p10_start_cbs(proc_target.front(), true);
+
+        std::cout << "phal-refactor Done HWP( start_cbs )\n";
+        if (fapirc == fapi2::FAPI2_RC_SUCCESS)
         {
-			if (ipl_type() == IPL_TYPE_MPIPL)
+            // Update Primary processor SBE state to
+            // check cfam. Boot error callback is
+            // only required for failure.
+            using namespace ipl::sbe;
+            ipl_sbe_set_state(proc_target.front(), ipl::sbe::SBE_STATE_CHECK_CFAM);
+
+            if (!ipl_sbe_booted(proc_target.front(), 25))
             {
-				ipl_error_type err = ipl::sbe::ipl_sbe_mpipl_continue(proc);
-				ipl_error_callback(err);
-				rc = err;
-			}
+                std::cout << "phal-refactor istep0.14 ( sbe_start ): sbe failed to boot\n";
+                //err_type = IPL_ERR_SBE_BOOT;
+            }
             else
             {
-				//ipl_error_type err_type = IPL_ERR_OK;
-
-                std::cout << "p12-refactor executing HWP-start_cbs\n";
-				fapirc = p10_start_cbs(proc, true);
-
-                std::cout << "p12-refactor done HWP-start_cbs\n";
-                if (fapirc == fapi2::FAPI2_RC_SUCCESS)
-                {
-					// Update Primary processor SBE state to
-					// check cfam. Boot error callback is
-					// only required for failure.
-                    using namespace ipl::sbe;
-					ipl_sbe_set_state(proc, ipl::sbe::SBE_STATE_CHECK_CFAM);
-
-                    if (!ipl_sbe_booted(proc, 25))
-                    {
-                        std::cout << "p12-refactor istep0-sbe_start: sbe did not boot\n";
-						//err_type = IPL_ERR_SBE_BOOT;
-					}
-                    else
-                    {
-						// Update Primary processor SBE
-						// state to booted Boot error
-						// callback is only required for
-						// failure.
-						ipl_sbe_set_state(proc, ipl::sbe::SBE_STATE_BOOTED);
-						rc = 0;
-					}
-				}
-                else
-                {
-					//err_type = IPL_ERR_HWP;
-				}
-				//ipl_error_callback(err_type);
-				break;
-			}
-		}
-	}
+                // Update Primary processor SBE
+                // state to booted Boot error
+                // callback is only required for
+                // failure.
+                ipl_sbe_set_state(proc_target.front(), ipl::sbe::SBE_STATE_BOOTED);
+                rc = 0;
+            }
+        }
+        else
+        {
+            //err_type = IPL_ERR_HWP;
+        }
+        //ipl_error_callback(err_type);
+    }
 
 	if (!rc)
     {
@@ -1500,7 +1406,7 @@ catch(const std::exception& ex)
     std::cout << "exception during sbe_start exception: " << ex.what() << std::endl;
 }
     
-    std::cout << "p12-refactor istep0-sbe_start: done\n";
+    std::cout << "phal-refactor istep0.14 ( sbe_start ): done\n";
     return rc;
 }
 
@@ -1511,6 +1417,7 @@ static int ipl_startPRD(void)
 
 static int ipl_proc_attn_listen(void)
 {
+    std::cout << "phal-refactor istep0.16 ( proc_attn_listen ): started\n";
     using namespace TARGETING;
 
     auto& ts = TargetService::instance();
@@ -1521,26 +1428,12 @@ static int ipl_proc_attn_listen(void)
     PredicatePostfixExpr masterFuncProcPred;
     masterFuncProcPred.push(typeProc).push(masterProc).And();
    
-    auto isMc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_MC);
-    auto isCore = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_CORE);
-    auto isPauc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAUC);
-    auto isPau = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PAU);
-    auto isIohs = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_IOHS);
-    auto isPec = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PEC);
-    auto isFc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_FC);
-
-    PredicatePostfixExpr expr;
-    expr.push(isMc).push(isCore).Or()
-        .push(isPauc).push(isPau).Or()
-        .push(isIohs).push(isPec).Or()
-        .push(isFc).Or();
-
     auto proc_target = ts.getAssociated(top, AssociationType::childByPhysical,
                              RecursionLevel::all, &masterFuncProcPred);
  
     if(proc_target.empty() || (proc_target.size() != 1))
     {
-        std::cerr << "p12-refactor istep0-ipl_proc_attn_listen: invalid master proc count\n";
+        std::cerr << "phal-refactor istep0.16 ( proc_attn_listen ): invalid master proc count\n";
         return 1;
     }
    
@@ -1578,6 +1471,8 @@ static int ipl_proc_attn_listen(void)
 	}
 
 	ipl_error_callback((rc == 0) ? IPL_ERR_OK : IPL_ERR_FSI_REG);
+
+    std::cout << "phal-refactor istep0.16 ( proc_attn_listen ): done\n";
 	return rc;	
 }
 

--- a/libipl/p10/ipl_poweroff.C
+++ b/libipl/p10/ipl_poweroff.C
@@ -28,7 +28,7 @@ int ipl_pre_poweroff(void)
 			"Running p10_pre_poweroff HWP on processor %d\n",
 			pdbg_target_index(proc));
 
-		fapi_rc = p10_pre_poweroff(proc);
+		//TODO p12-refactor fapi_rc = p10_pre_poweroff(proc);
 		if (fapi_rc != fapi2::FAPI2_RC_SUCCESS) {
 			ipl_log(IPL_ERROR,
 				"p10_pre_poweroff failed for proc index %d\n",

--- a/libipl/p10/ipl_sbe.C
+++ b/libipl/p10/ipl_sbe.C
@@ -1,0 +1,216 @@
+extern "C"
+{
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+}
+
+#include <iostream>
+#include <iomanip>
+
+#include "ipl_sbe.H"
+#include "libipl_internal.H"
+#include "common.H"
+#include "plat_utils.H"
+
+#include <targeting/predicates/predicateattrval.H>
+#include <targeting/predicates/predicateisfunctional.H>
+#include <targeting/predicates/predicatepostfixexpr.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
+
+#include <ekb/hwpf/fapi2/include/return_code_defs.H>
+#include <ekb/chips/p10/procedures/hwp/istep/p10_do_fw_hb_istep.H>
+#include <ekb/chips/p10/procedures/hwp/sbe/p10_get_sbe_msg_register.H>
+
+namespace ipl::sbe
+{
+using namespace TARGETING;
+int ipl_sbe_set_state(TARGETING::ConstTargetPtr target, enum sbe_state state)
+{
+    return hwaccess::HwAccessIntf::putCfamRegister(target, SBE_STATE_REG, 
+                                                   static_cast<uint32_t>(state));
+}
+
+int ipl_sbe_get_state(TARGETING::ConstTargetPtr target, enum sbe_state *state)
+{
+    union sbe_msg_register msg;
+    uint32_t value;
+
+    int rc = hwaccess::HwAccessIntf::getCfamRegister(target, SBE_STATE_REG, value);
+
+    if (rc)
+        return rc;
+
+    if (value == SBE_STATE_CHECK_CFAM)
+    {
+        rc = hwaccess::HwAccessIntf::getCfamRegister(target, SBE_MSG_REG, msg.reg);
+
+        if (rc)
+			return rc;
+
+		*state = msg.sbe_booted ? SBE_STATE_BOOTED : SBE_STATE_CHECK_CFAM;
+    }
+    else
+    {
+		*state = static_cast<sbe_state>(value);
+	}
+
+    return rc;
+}
+
+int sbe_mpipl_continue(TARGETING::ConstTargetPtr /*target*/)
+{
+    //TODO p12-refactor
+	/*struct chipop *chipop;
+	int rc;
+
+	chipop = pib_to_chipop(target);
+	if (!chipop)
+		return -1;
+
+	if (!chipop->mpipl_continue) {
+		PR_ERROR("mpipl_continue() not implemented for the target\n");
+		return -1;
+	}
+
+	rc = chipop->mpipl_continue(chipop);
+	if (rc) {
+		PR_ERROR("sbe mpipl_continue() returned rc=%d\n", rc);
+		return -1;
+	}*/
+	return 0;
+}
+
+ipl_error_type ipl_sbe_mpipl_continue(TARGETING::ConstTargetPtr /*target*/)
+{
+    /*TODO p12-refactor
+	enum sbe_state state;
+	int rc = 0;
+
+	ipl_log(IPL_INFO, "ipl_sbe_mpipl_continue: Enter(%s)", pdbg_target_path(proc));
+
+    rc = ipl_sbe_get_state(target, &state);
+
+    if (rc != 0)
+    {
+		ipl_log(IPL_ERROR, "Failed to read SBE state information (%s)", pdbg_target_path(pib));
+		return IPL_ERR_FSI_REG;
+	}
+
+	// SBE_STATE_CHECK_CFAM case is already handled by ipl_sbe_get_state function
+	if (state != SBE_STATE_BOOTED)
+    {
+		ipl_log(IPL_ERROR,
+			"SBE (%s) is not ready for chip-op: state(0x%08x)",
+			pdbg_target_path(pib), state);
+		return IPL_ERR_SBE_CHIPOP;
+	}
+
+	rc = sbe_mpipl_continue(target);
+
+	if (rc != 0)
+    {
+		ipl_log(IPL_ERROR, "SBE (%s) mpipl continue chip-op failed", pdbg_target_path(pib));
+		return IPL_ERR_SBE_CHIPOP;
+	}*/
+
+	return IPL_ERR_OK;
+}
+
+bool ipl_sbe_booted(TARGETING::TargetPtr target, uint32_t wait_time_seconds)
+{
+	sbeMsgReg_t sbeReg;
+	fapi2::ReturnCode fapi_rc;
+	uint32_t loopcount;
+
+	loopcount = wait_time_seconds > 0 ? wait_time_seconds : 25;
+
+	while (loopcount > 0)
+    {
+        std::cout << "p12-refactor executing p10_get_sbe_msg_register\n";
+	    fapi_rc = p10_get_sbe_msg_register(target, sbeReg);
+
+        if (fapi_rc == fapi2::FAPI2_RC_SUCCESS)
+        {
+			if (sbeReg.sbeBooted)
+            {
+                std::cout << "p12-refactor SBE Booted, wait time: " << loopcount << "\n";
+				ipl_log(IPL_INFO,
+					"SBE booted. sbeReg[0x%08x] Wait time: "
+					"[%d]\n",
+					uint32_t(sbeReg.reg), loopcount);
+				return true;
+			}
+            else
+            {
+                std::cout << "p12-refactor SBE boot is in progress. sbeReg[0x"
+                     << std::hex << std::setw(8) << std::setfill('0') << uint32_t(sbeReg.reg)
+                     << "]" << std::dec << std::endl;
+			}
+		}
+        else
+        {
+            std::cerr << "p12-refactor p10_get_sbe_msg_register failed fapi_rc = 0x"
+                << std::hex << static_cast<uint32_t>(fapi_rc)
+                << std::dec << std::endl;
+			
+            /*TODO ipl_log(IPL_ERROR,
+				"p10_get_sbe_msg_register failed for proc %d, "
+				"rc=%d\n",
+				pdbg_target_index(proc), fapi_rc);*/
+		}
+
+		loopcount--;
+		sleep(1);
+	}
+
+	// Get SBE debug data.
+	uint32_t val = 0xFFFFFFFF;
+
+    int rc = hwaccess::HwAccessIntf::getCfamRegister(target, 0x1007, val);
+
+    if (rc)
+    {
+		//TODO ipl_log(IPL_ERROR, "CFAM(0x1007) on %s failed", pdbg_target_path(fsi));
+	}
+
+    std::cout << "p12-refactor SBE Debug Data: 0x2809[0x"
+          << std::hex << std::setw(8) << std::setfill('0') << uint32_t(sbeReg.reg)
+          << "]  0x1007[0x"
+          << std::hex << std::setw(8) << std::setfill('0') << val
+          << "]" << std::dec << std::endl;
+    
+    return false;
+}
+
+int ipl_set_sbe_state_all(enum sbe_state state, bool skipMaster)
+{
+    using namespace TARGETING;
+    
+    int ret = 0;
+    auto& ts = TargetService::instance();
+
+    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
+
+    auto top = ts.getTopLevelTarget();
+
+    for (auto&& proc :
+            ts.getAssociated(top, AssociationType::childByPhysical,
+                             RecursionLevel::all, &pred))
+    {
+        if(skipMaster && ipl_is_master_proc(proc))
+            continue;
+
+		if (ipl_is_present(proc))
+        {
+			if (ipl_sbe_set_state(proc, state))
+            {
+				ret = 1;
+			}
+		}
+	}
+	return ret;
+}
+
+} // namespace ipl::sbe

--- a/libipl/p10/ipl_sbe.C
+++ b/libipl/p10/ipl_sbe.C
@@ -61,7 +61,7 @@ int ipl_sbe_get_state(TARGETING::ConstTargetPtr target, enum sbe_state *state)
 
 int sbe_mpipl_continue(TARGETING::ConstTargetPtr /*target*/)
 {
-    //TODO p12-refactor
+    //TODO phal-refactor
 	/*struct chipop *chipop;
 	int rc;
 
@@ -84,7 +84,7 @@ int sbe_mpipl_continue(TARGETING::ConstTargetPtr /*target*/)
 
 ipl_error_type ipl_sbe_mpipl_continue(TARGETING::ConstTargetPtr /*target*/)
 {
-    /*TODO p12-refactor
+    /*TODO phal-refactor
 	enum sbe_state state;
 	int rc = 0;
 
@@ -128,30 +128,31 @@ bool ipl_sbe_booted(TARGETING::TargetPtr target, uint32_t wait_time_seconds)
 
 	while (loopcount > 0)
     {
-        std::cout << "p12-refactor executing p10_get_sbe_msg_register\n";
+        std::cout << "phal-refactor executing p10_get_sbe_msg_register\n";
 	    fapi_rc = p10_get_sbe_msg_register(target, sbeReg);
 
         if (fapi_rc == fapi2::FAPI2_RC_SUCCESS)
         {
 			if (sbeReg.sbeBooted)
             {
-                std::cout << "p12-refactor SBE Booted, wait time: " << loopcount << "\n";
-				ipl_log(IPL_INFO,
+                std::cout << std::dec 
+                          << "phal-refactor SBE Booted, wait time: " << loopcount << "\n";
+				/*ipl_log(IPL_INFO,
 					"SBE booted. sbeReg[0x%08x] Wait time: "
 					"[%d]\n",
-					uint32_t(sbeReg.reg), loopcount);
+					uint32_t(sbeReg.reg), loopcount);*/
 				return true;
 			}
             else
             {
-                std::cout << "p12-refactor SBE boot is in progress. sbeReg[0x"
+                std::cout << "phal-refactor SBE boot is in progress. sbeReg[0x"
                      << std::hex << std::setw(8) << std::setfill('0') << uint32_t(sbeReg.reg)
                      << "]" << std::dec << std::endl;
 			}
 		}
         else
         {
-            std::cerr << "p12-refactor p10_get_sbe_msg_register failed fapi_rc = 0x"
+            std::cerr << "phal-refactor p10_get_sbe_msg_register failed fapi_rc = 0x"
                 << std::hex << static_cast<uint32_t>(fapi_rc)
                 << std::dec << std::endl;
 			
@@ -175,7 +176,7 @@ bool ipl_sbe_booted(TARGETING::TargetPtr target, uint32_t wait_time_seconds)
 		//TODO ipl_log(IPL_ERROR, "CFAM(0x1007) on %s failed", pdbg_target_path(fsi));
 	}
 
-    std::cout << "p12-refactor SBE Debug Data: 0x2809[0x"
+    std::cout << "phal-refactor SBE Debug Data: 0x2809[0x"
           << std::hex << std::setw(8) << std::setfill('0') << uint32_t(sbeReg.reg)
           << "]  0x1007[0x"
           << std::hex << std::setw(8) << std::setfill('0') << val
@@ -191,23 +192,26 @@ int ipl_set_sbe_state_all(enum sbe_state state, bool skipMaster)
     int ret = 0;
     auto& ts = TargetService::instance();
 
-    PredicateAttrVal<ATTR_TYPE> pred(TYPE_PROC);
-
     auto top = ts.getTopLevelTarget();
+    
+    auto typeProc = std::make_shared<PredicateAttrVal<ATTR_TYPE>>(TYPE_PROC);
+    auto masterProc = std::make_shared<PredicateAttrVal<ATTR_PROC_MASTER_TYPE>>(0);
+    PredicatePostfixExpr predExpr;
+    
+    predExpr.push(typeProc);
 
+    if(skipMaster)
+    {
+        predExpr.push(masterProc).Not().And();
+    }
+   
     for (auto&& proc :
             ts.getAssociated(top, AssociationType::childByPhysical,
-                             RecursionLevel::all, &pred))
+                             RecursionLevel::all, &predExpr))
     {
-        if(skipMaster && ipl_is_master_proc(proc))
-            continue;
-
-		if (ipl_is_present(proc))
+		if (ipl_is_present(proc) && ipl_sbe_set_state(proc, state))
         {
-			if (ipl_sbe_set_state(proc, state))
-            {
-				ret = 1;
-			}
+			ret = 1;
 		}
 	}
 	return ret;

--- a/libipl/p10/ipl_sbe.H
+++ b/libipl/p10/ipl_sbe.H
@@ -7,7 +7,11 @@
 
 /*The sbe register and state values in this file picked
   from libpdbg/libpdbg_sbe.H & libpdbg/sbe_api.C to decouple
-  targeting-sbe method's dependency on pdbg library*/
+  targeting-sbe method's dependency on pdbg library
+TODO:
+Check: these values differ with the values defined in 
+sbe/public/src/runtime/common/core/sbestates.H*/
+
 
 namespace ipl::sbe
 {

--- a/libipl/p10/ipl_sbe.H
+++ b/libipl/p10/ipl_sbe.H
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "libipl.H"
+#include <targeting/target.H>
+#include <targeting/target_service.H>
+#include <hwaccess/hw_access_intf.H>
+
+/*The sbe register and state values in this file picked
+  from libpdbg/libpdbg_sbe.H & libpdbg/sbe_api.C to decouple
+  targeting-sbe method's dependency on pdbg library*/
+
+namespace ipl::sbe
+{
+#define SBE_MSG_REG	0x2809
+#define SBE_STATE_REG	0x2986
+
+enum sbe_state {
+	SBE_STATE_NOT_USABLE  = 0x00000000,
+	SBE_STATE_BOOTED      = 0x00000001,
+	SBE_STATE_CHECK_CFAM  = 0x00000002,
+	SBE_STATE_DEBUG_MODE  = 0x00000003,
+	SBE_STATE_FAILED      = 0x00000004,
+
+	SBE_STATE_INVALID     = 0x0000000F,
+};
+
+enum {
+	SBE_MSG_STATE_UNKNOWN = 0x0,
+	SBE_MSG_STATE_IPLING  = 0x1,
+	SBE_MSG_STATE_ISTEP   = 0x2,
+	SBE_MSG_STATE_MPIPL   = 0x3,
+	SBE_MSG_STATE_RUNTIME = 0x4,
+	SBE_MSG_STATE_DMT     = 0x5,
+	SBE_MSG_STATE_DUMP    = 0x6,
+	SBE_MSG_STATE_FAILURE = 0x7,
+	SBE_MSG_STATE_QUIESCE = 0x8,
+
+	SBE_MSG_STATE_INVALID = 0xF,
+};
+
+union sbe_msg_register {
+	uint32_t reg;
+	struct {
+		uint32_t reserved2: 6;
+		uint32_t minor_step: 6;
+		uint32_t major_step: 8;
+		uint32_t curr_state: 4;
+		uint32_t prev_state: 4;
+		uint32_t reserved1: 2;
+		uint32_t async_ffdc: 1;
+		uint32_t sbe_booted: 1;
+	};
+};
+
+
+int ipl_sbe_set_state(TARGETING::ConstTargetPtr target, enum sbe_state state);
+int ipl_sbe_get_state(TARGETING::ConstTargetPtr target, enum sbe_state *state);
+int sbe_mpipl_continue(TARGETING::ConstTargetPtr target);
+bool ipl_sbe_booted(TARGETING::TargetPtr target, uint32_t wait_time_seconds);
+int ipl_set_sbe_state_all(enum sbe_state state, bool skipMaster=false);
+ipl_error_type ipl_sbe_mpipl_continue(TARGETING::ConstTargetPtr target);
+} // namespace ipl::sbe

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -10,6 +10,8 @@
 #include <set>
 #include <expected>
 
+#include <targeting/target_service.H>
+
 namespace openpower::phal::pdbg
 {
 
@@ -22,6 +24,7 @@ void init(pdbg_backend pdbgBackend, const int32_t logLevel,
 {
 	log(level::INFO, "PDBG Initilization started");
 
+    TARGETING::TargetService::instance().init("/tmp/targeting_test.dtb");
 	// set PDBG Back-end
 	if (!pdbg_set_backend(pdbgBackend, NULL)) {
 		log(level::ERROR, "Failed to set pdbg back-end(%d)",

--- a/libphal/phal_sbe.C
+++ b/libphal/phal_sbe.C
@@ -118,6 +118,7 @@ void sbeHaltStateRecovery(struct pdbg_target* proc,
         throw pdbgError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
     }
 
+    /* TODO p12-refactor
     // get SBE current state based on sbe message register
     sbeMsgReg_t sbeReg;
     fapi2::ReturnCode fapiRC;
@@ -171,7 +172,7 @@ void sbeHaltStateRecovery(struct pdbg_target* proc,
         log(level::ERROR, "SBE (%s), Fail to recover from halt state",
             pdbg_target_path(proc));
         logSbeDebugData(proc);
-    }
+    }*/
 }
 
 void validateSBEState(struct pdbg_target* chip)


### PR DESCRIPTION
This PR attempts to move istep0 substeps to use targeting libraries and move away from pdbg library framework.
Changes are partial and to the extent to be able to demo ipl istep0. Future commits will move the TODO list of tasks to transition to targeting completely. 