### PR TITLE
phal: Hardware procedure error handling support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ libphal_la_SOURCES = \
 	error/errl_factory.C \
 	error/errl_handle.C \
 	error/sbe_boot_failure.C \
+	error/sbe_hwp_failure.C \
 	error/sbe_error_helper.C \
 	error/sbe_nofunc_proc.C \
 	error/poz_sbe_chipop_failure.C \

--- a/error/errl_factory.C
+++ b/error/errl_factory.C
@@ -1,6 +1,7 @@
 #include <errl_factory.H>
 #include <poz_sbe_chipop_failure.H>
 #include <sbe_boot_failure.H>
+#include <sbe_hwp_failure.H>
 #include <sbe_nofunc_proc.H>
 
 namespace errl::factory
@@ -10,6 +11,12 @@ std::optional<std::unique_ptr<ErrlHandle>>
 {
     return errl::sbe_boot_failure::create(target);
 }
+
+std::optional<std::unique_ptr<ErrlHandle>> createSbeHWPFailure()
+{
+    return errl::sbe_hwp_failure::create();
+}
+
 std::optional<std::unique_ptr<ErrlHandle>>
     createPozSbeChipOpFailure(pdbg_target* target)
 {

--- a/error/errl_factory.H
+++ b/error/errl_factory.H
@@ -46,4 +46,16 @@ std::optional<std::unique_ptr<ErrlHandle>>
  */
 std::optional<std::unique_ptr<ErrlHandle>> createSbeNoFuncProc();
 
+/** @brief Create an error log for an SBE HWP failure.
+ *
+ *  Constructs and returns an error log entry specific to SBE (Self Boot Engine)
+ *  HWP failure scenarios on the given target.
+ *
+ *  @param[in] target - The hardware target (pdbg_target) associated with the
+ * failure.
+ *  @return std::optional containing a unique_ptr to ErrlHandle if creation
+ * succeeds, std::nullopt otherwise.
+ */
+std::optional<std::unique_ptr<ErrlHandle>> createSbeHWPFailure();
+
 } // namespace errl::factory

--- a/error/errl_util.C
+++ b/error/errl_util.C
@@ -73,6 +73,8 @@ int convertFAPItoPELformat(
         userData.emplace(prefix + "HW_ID", hwCallout.hwid);
         userData.emplace(prefix + "PRIORITY", hwCallout.callout_priority);
 
+        // TODO: this code need to be ported over to TARGETING
+        /*
         assert(hwCallout.target_entity_path.size() ==
                sizeof(ATTR_PHYS_BIN_PATH_Type));
         const auto& physBinPath =
@@ -96,7 +98,7 @@ int convertFAPItoPELformat(
         {
             userData.emplace(prefix + "PHYS_PATH", physDevPath);
         }
-
+        */
         userData.emplace(prefix + "CLK_POS", std::to_string(hwCallout.clkPos));
         userData.emplace(prefix + "CALLOUT_PLANAR",
                          hwCallout.isPlanarCallout ? "true" : "false");
@@ -117,6 +119,8 @@ int convertFAPItoPELformat(
     {
         std::string prefix = std::format("HWP_CDG_TGT_{:02}_", ++calloutCount);
 
+        // TODO: this code need to be ported over to TARGETING
+        /*
         assert(cdg.target_entity_path.size() ==
                sizeof(ATTR_PHYS_BIN_PATH_Type));
         const auto& physBinPath =
@@ -139,7 +143,7 @@ int convertFAPItoPELformat(
         {
             userData.emplace(prefix + "PHYS_PATH", physDevPath);
         }
-
+        */
         userData.emplace(prefix + "CO_REQ", cdg.callout ? "true" : "false");
         userData.emplace(prefix + "CO_PRIORITY", cdg.callout_priority);
         userData.emplace(prefix + "DECONF_REQ",
@@ -153,13 +157,15 @@ int convertFAPItoPELformat(
                             {"GuardType", cdg.guard_type},
                             {"EntityPath", cdg.target_entity_path}};
 
+        // TODO: this code need to be ported over to TARGETING
+        /*
         ATTR_MRU_ID_Type mruId;
         if (DT_GET_PROP(ATTR_MRU_ID, *target, mruId) == 0)
         {
             calloutJson["MRUs"] = json::array(
                 {{{"ID", mruId}, {"Priority", calloutJson["Priority"]}}});
         }
-
+        */
         callout.emplace_back(std::move(calloutJson));
     }
 

--- a/error/sbe_hwp_failure.C
+++ b/error/sbe_hwp_failure.C
@@ -1,0 +1,24 @@
+#include <errl_util.H>
+#include <libekb.H>
+#include <sbe_hwp_failure.H>
+
+#include <string>
+namespace errl::sbe_hwp_failure
+{
+std::optional<std::unique_ptr<ErrlHandle>> create()
+{
+    FFDC ffdc;
+    libekb_get_ffdc(ffdc);
+
+    json callout = json::array();
+    std::unordered_map<std::string, std::string> effdcUserData;
+    errl::util::convertFAPItoPELformat(ffdc, callout, effdcUserData);
+
+    std::string errMsg = "org.open_power.PHAL.Error.Boot";
+    auto handle = std::make_unique<errl::ErrlHandle>();
+    auto errl = std::make_unique<errl::ErrlEntry>(
+        errMsg, effdcUserData, std::make_optional(std::move(callout)));
+    handle->addEntry(std::move(errl));
+    return handle;
+}
+} // namespace errl::sbe_hwp_failure

--- a/error/sbe_hwp_failure.H
+++ b/error/sbe_hwp_failure.H
@@ -1,0 +1,17 @@
+#pragma once
+#include <errl_handle.H>
+
+#include <memory>
+
+namespace errl::sbe_hwp_failure
+{
+/** @brief Create an error handle for a hardware procedure failure.
+ *
+ *  Constructs and returns an error log handle specific to a hardware
+ *  procedure failure during boot scenario on the provided hardware target.
+ *
+ *  @return std::optional containing a unique_ptr to ErrlHandle if creation
+ * succeeds, std::nullopt otherwise.
+ */
+std::optional<std::unique_ptr<ErrlHandle>> create();
+} // namespace errl::sbe_hwp_failure

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -1380,10 +1380,6 @@ try{
                 rc = 0;
             }
         }
-        else
-        {
-            //err_type = IPL_ERR_HWP;
-        }
         //ipl_error_callback(err_type);
     }
 


### PR DESCRIPTION
Test result:

root@xxx:~# peltool -i 0x50000842
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc host processor control",
    "Created at":               "12/02/2025 06:38:08",
    "Committed at":             "12/02/2025 06:38:08",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x50000842",
    "Entry Id":                 "0x50000842",
    "BMC Event Log Id":         "753"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "CEC Hardware",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Unrecoverable Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},s
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc host processor control",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "Failure occurred during boot process"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD503001",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000"
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9105-22B",
    "Reporting Serial Number":  "139F210",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1210.00-1.21",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD503001_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Machine Type Model":       "9105-22B",
    "Serial Number":            "139F210"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "BMCLoad": "1.54 1.16 1.15",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 1h 44m 17s",
    "BootState": "Unspecified",
    "ChassisState": "TransitioningToOn",
    "FW Version ID": "fw1210.00-1.21-3-g1df0c30c21-dirty",
    "HostState": "TransitioningToRunning",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "HWP_CDG_TGT_01_CO_PRIORITY": "MEDIUM",
    "HWP_CDG_TGT_01_CO_REQ": "true",
    "HWP_CDG_TGT_01_DECONF_REQ": "true",
    "HWP_CDG_TGT_01_GUARD_REQ": "true",
    "HWP_CDG_TGT_01_GUARD_TYPE": "GARD_Fatal",
    "HWP_FFDC_AVS_BUS": "01",
    "HWP_FFDC_AVS_RAIL": "00",
    "HWP_FFDC_CBS_ENVSTAT_READ": "3c000020",
    "HWP_HW_CO_01_CALLOUT_PLANAR": "false",
    "HWP_HW_CO_01_CLK_POS": "255",
    "HWP_HW_CO_01_HW_ID": "UN_SUPPORTED_PART",
    "HWP_HW_CO_01_PRIORITY": "HIGH",
    "HWP_RC": "RC_VDN_PGOOD_NOT_SET",
    "HWP_RC_DESC": "Nest power (VDN) Power Good indication not set"
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "Data": [
        {
            "Deconfigured": true,
            "EntityPath": [
                35,
                1,
                0,
                2,
                0,
                5,
                0
            ],
            "GuardType": "GARD_Fatal",
            "Guarded": true,
            "Priority": "M"
        }
    ]
},
"User Data 3": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "PEL Internal Debug Data": {
        "SRC": [
            "Failed extracting callout data from JSON: JSON callout needs either an inventory path or location code"
        ]
    }
}
}

Change-Id: I4feafbbd38eaa1971abf32a37901c498e2e34b73