### PR TITLE
guard: Clear ephemeral guard records during ipl

### DIFF
--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -448,7 +448,7 @@ static void process_guard_records()
 				if ((ipl_type() == IPL_TYPE_NORMAL) &&
 				    openpower::guard::isEphemeralType(
 					elem.errType)) {
-					openpower::guard::clear(elem.recordId);
+					openpower::guard::clear(elem.recordId, true);
 					targetinfo.set_hwas_state = true;
 				} else {
 					targetinfo.set_hwas_state = false;


### PR DESCRIPTION
Ephemeral guard records are not passing the checks of not being either manual guard or core guard without force clear flag.

This is throwing exception of cannot delete non-core guard record.

Test Results:
```
Balcones system:
BEFORE
balco11host openpower-proc-control[4751]: Istep: updatehwmodel: started
balco11host openpower-proc-control[4751]: Number of Records = 2
balco11host openpower-proc-control[4751]: Applying guard record for physical:sys-0/node-0/proc-0/mc-1. Type: unrecoverable
balco11host openpower-proc-control[4751]: Caught the exception Cannot delete a non-core system generated guard record
and continuing to boot without processing guard records
balco11host openpower-proc-control[4751]: proc on Hostboot value

Rainier system:
Created ephemeral guard, and ipled, system cleared the ephemeral guard
record, and ipled.
root@p11bmc:~# guard -e
ID         | ERROR      | Type            | Path
0xffffffff | 0x00000000 | reconfig        | physical:sys-0/node-0/dimm-2
0x00000001 | 0x00000000 | reconfig        | physical:sys-0/node-0/dimm-1
root@p11bmc:~# guard -e
ID         | ERROR      | Type            | Path
0xffffffff | 0x00000000 | reconfig        | physical:sys-0/node-0/dimm-2
0xffffffff | 0x00000000 | reconfig        | physical:sys-0/node-0/dimm-1
```